### PR TITLE
feat(efcore): capture relational commands on EF Core 8 and 10 [QG-014]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,6 +98,44 @@ jobs:
           path: artifacts/test-results
           if-no-files-found: warn
 
+  integration-tests:
+    name: integration-tests
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
+        with:
+          dotnet-version: |
+            8.0.x
+            10.0.x
+
+      - name: Restore
+        run: dotnet restore QueryGuard.slnx
+
+      - name: Build
+        run: dotnet build QueryGuard.slnx -c Release --no-restore
+
+      # Real relational command execution against SQLite. A fake interceptor would prove
+      # nothing about which methods EF Core actually calls.
+      - name: Run integration tests
+        run: >-
+          dotnet test tests/QueryGuard.EntityFrameworkCore.Tests/QueryGuard.EntityFrameworkCore.Tests.csproj
+          -c Release --no-build
+          --logger "trx;LogFileName=integration-tests.trx"
+          --results-directory artifacts/test-results
+
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        if: always()
+        with:
+          name: integration-tests-${{ matrix.os }}
+          path: artifacts/test-results
+          if-no-files-found: warn
+
   package-validate:
     name: package-validate
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@ record: breaking changes, privacy-relevant behavior, and report-schema compatibi
 
 ### Added
 
+- `QueryGuard.EntityFrameworkCore`: captures relational command execution through the official
+  `DbCommandInterceptor` API on EF Core 8 and 10, covering the synchronous and asynchronous reader,
+  scalar, and non-query paths plus command failures. Observes only — the generated SQL, the result,
+  and the original exception are never modified.
+- `IQueryFingerprintFactory` with a stable SHA-256-derived identifier, and `QueryGuardQueryTag` for
+  recognizing `QueryGuard:` directives attached with EF Core `TagWith`.
 - Central privacy and redaction policy: `QueryGuardCaptureOptions` defines what may be captured
   and `IQueryGuardRedactor` enforces it before any reporter sees a result. Parameter values and
   connection strings are never captured, literals in SQL are redacted, retained samples and SQL

--- a/QueryGuard.slnx
+++ b/QueryGuard.slnx
@@ -15,8 +15,10 @@
   </Folder>
   <Folder Name="/src/">
     <Project Path="src/QueryGuard.Core/QueryGuard.Core.csproj" />
+    <Project Path="src/QueryGuard.EntityFrameworkCore/QueryGuard.EntityFrameworkCore.csproj" />
   </Folder>
   <Folder Name="/tests/">
     <Project Path="tests/QueryGuard.Core.Tests/QueryGuard.Core.Tests.csproj" />
+    <Project Path="tests/QueryGuard.EntityFrameworkCore.Tests/QueryGuard.EntityFrameworkCore.Tests.csproj" />
   </Folder>
 </Solution>

--- a/src/QueryGuard.Core/IQueryFingerprintFactory.cs
+++ b/src/QueryGuard.Core/IQueryFingerprintFactory.cs
@@ -1,0 +1,21 @@
+namespace QueryGuard;
+
+/// <summary>
+/// Turns a database command's text into a stable <see cref="QueryFingerprint"/>.
+/// </summary>
+/// <remarks>
+/// This is the seam that decides when two commands count as "the same query", which is the
+/// judgement the whole repeated-query feature rests on. It is an interface so that a provider whose
+/// SQL the generic implementation groups badly can be given a dedicated strategy without touching
+/// the detector. See <c>docs/decisions/0005-sql-fingerprints.md</c>.
+/// </remarks>
+public interface IQueryFingerprintFactory
+{
+    /// <summary>
+    /// Creates a fingerprint for a command.
+    /// </summary>
+    /// <param name="commandText">The command text as the provider produced it.</param>
+    /// <param name="kind">The kind of command.</param>
+    /// <returns>A fingerprint whose identifier is stable across runs, processes, and frameworks.</returns>
+    QueryFingerprint Create(string? commandText, QueryCommandKind kind);
+}

--- a/src/QueryGuard.Core/QueryFingerprintFactory.cs
+++ b/src/QueryGuard.Core/QueryFingerprintFactory.cs
@@ -1,0 +1,75 @@
+using System.Globalization;
+using System.Security.Cryptography;
+using System.Text;
+
+namespace QueryGuard;
+
+/// <summary>
+/// The default <see cref="IQueryFingerprintFactory"/>: redact, then hash.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The identifier appears in allowlist configuration, in issue reports, and in CI output, so it has
+/// to be identical across runs, processes, and both target frameworks.
+/// <see cref="string.GetHashCode()"/> is randomized per process and is therefore disqualified;
+/// this uses an explicit SHA-256 digest truncated to eight hex characters.
+/// </para>
+/// <para>
+/// Eight characters is 32 bits, which is short enough to paste into a configuration file or an
+/// issue title. Collisions are irrelevant at the scale that matters: a fingerprint only has to be
+/// unique among the handful of distinct statements inside one request or test, not globally.
+/// </para>
+/// <para>
+/// Text is redacted <em>before</em> hashing, never after, so two commands differing only by an
+/// inlined value share an identifier — and no un-redacted text is ever retained.
+/// </para>
+/// </remarks>
+public sealed class QueryFingerprintFactory : IQueryFingerprintFactory
+{
+    /// <summary>
+    /// How many hex characters of the digest form the identifier.
+    /// </summary>
+    private const int IdLength = 8;
+
+    private readonly IQueryGuardRedactor _redactor;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="QueryFingerprintFactory"/> class.
+    /// </summary>
+    /// <param name="redactor">
+    /// The redactor applied before hashing. Defaults to a redactor with default capture options.
+    /// </param>
+    public QueryFingerprintFactory(IQueryGuardRedactor? redactor = null)
+        => _redactor = redactor ?? new QueryGuardRedactor();
+
+    /// <inheritdoc />
+    public QueryFingerprint Create(string? commandText, QueryCommandKind kind)
+    {
+        var normalized = _redactor.RedactSql(commandText);
+        return new QueryFingerprint(ComputeId(normalized, kind), normalized);
+    }
+
+    private static string ComputeId(string normalizedSql, QueryCommandKind kind)
+    {
+        // The command kind participates in the identifier so that a read and a write which happen
+        // to normalize to the same text are never grouped together. It is written as its numeric
+        // value followed by a colon, which keeps the payload unambiguous without embedding a
+        // control character in the source.
+        var payload = string.Create(
+            CultureInfo.InvariantCulture,
+            $"{(int)kind}:{normalizedSql}");
+
+        var digest = SHA256.HashData(Encoding.UTF8.GetBytes(payload));
+
+        var builder = new StringBuilder(
+            QueryFingerprint.IdPrefix,
+            QueryFingerprint.IdPrefix.Length + IdLength);
+
+        for (var i = 0; i < IdLength / 2; i++)
+        {
+            builder.Append(digest[i].ToString("X2", CultureInfo.InvariantCulture));
+        }
+
+        return builder.ToString();
+    }
+}

--- a/src/QueryGuard.Core/QueryGuardQueryTag.cs
+++ b/src/QueryGuard.Core/QueryGuardQueryTag.cs
@@ -1,0 +1,175 @@
+using System;
+using System.Collections.Generic;
+
+namespace QueryGuard;
+
+/// <summary>
+/// Recognizes QueryGuard directives that travel with a query as an EF Core tag.
+/// </summary>
+/// <remarks>
+/// <para>
+/// EF Core's <c>TagWith</c> emits its argument as a leading SQL comment. That makes it the one place
+/// a developer can attach an instruction to a specific LINQ query, right where the query is written,
+/// rather than in a configuration file that drifts away from it.
+/// </para>
+/// <para>
+/// Only the recognized <c>QueryGuard:</c> prefix is retained. An arbitrary tag is a comment like any
+/// other and is stripped during normalization — QueryGuard does not keep text it was not asked to
+/// interpret.
+/// </para>
+/// </remarks>
+/// <example>
+/// <code>
+/// var items = await db.Items
+///     .TagWith("QueryGuard:Ignore reason=bounded-reference-lookup")
+///     .ToListAsync();
+/// </code>
+/// </example>
+public static class QueryGuardQueryTag
+{
+    /// <summary>
+    /// The prefix that marks a comment as a QueryGuard directive.
+    /// </summary>
+    public const string Prefix = "QueryGuard:";
+
+    /// <summary>
+    /// The directive that marks a query's repetition as intentional.
+    /// </summary>
+    /// <remarks>
+    /// A finding matched by this directive is reported as <em>ignored</em>, with its reason, and is
+    /// never removed. An allowlist that silently deletes findings becomes the place real problems go
+    /// to die.
+    /// </remarks>
+    public const string IgnoreDirective = "QueryGuard:Ignore";
+
+    /// <summary>
+    /// Extracts every QueryGuard directive from a command's leading comments.
+    /// </summary>
+    /// <param name="commandText">The command text, which may be <see langword="null"/>.</param>
+    /// <returns>
+    /// The directives found, or <see langword="null"/> when there are none — which is the common case
+    /// and avoids allocating an empty collection per command.
+    /// </returns>
+    /// <remarks>
+    /// Only line comments are scanned, because that is what <c>TagWith</c> produces. Scanning stops
+    /// at the first line that is neither blank nor a comment: a directive belongs at the top of the
+    /// statement, and reading the whole statement on every command would be work done for nothing.
+    /// </remarks>
+    public static IReadOnlyList<string>? Extract(string? commandText)
+    {
+        if (string.IsNullOrEmpty(commandText))
+        {
+            return null;
+        }
+
+        // A statement without the prefix anywhere is the overwhelmingly common case, and this one
+        // check keeps it to a single scan with no allocation.
+        if (!commandText.Contains(Prefix, StringComparison.Ordinal))
+        {
+            return null;
+        }
+
+        List<string>? tags = null;
+        var position = 0;
+
+        while (position < commandText.Length)
+        {
+            var lineEnd = commandText.IndexOf('\n', position);
+            var line = lineEnd < 0
+                ? commandText.AsSpan(position)
+                : commandText.AsSpan(position, lineEnd - position);
+
+            var trimmed = line.Trim();
+
+            if (trimmed.Length == 0)
+            {
+                position = Advance(lineEnd, commandText.Length);
+                continue;
+            }
+
+            if (!trimmed.StartsWith("--", StringComparison.Ordinal))
+            {
+                break;
+            }
+
+            var comment = trimmed[2..].Trim();
+            if (comment.StartsWith(Prefix, StringComparison.Ordinal))
+            {
+                tags ??= [];
+                tags.Add(comment.ToString());
+            }
+
+            position = Advance(lineEnd, commandText.Length);
+        }
+
+        return tags;
+    }
+
+    /// <summary>
+    /// Determines whether a set of tags asks QueryGuard to treat the query's repetition as
+    /// intentional.
+    /// </summary>
+    /// <param name="tags">The tags recognized on a command.</param>
+    /// <returns><see langword="true"/> when an ignore directive is present.</returns>
+    public static bool HasIgnoreDirective(IReadOnlyList<string>? tags)
+    {
+        if (tags is null)
+        {
+            return false;
+        }
+
+        for (var i = 0; i < tags.Count; i++)
+        {
+            if (tags[i].StartsWith(IgnoreDirective, StringComparison.Ordinal))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Reads the reason a query's repetition was declared intentional.
+    /// </summary>
+    /// <param name="tags">The tags recognized on a command.</param>
+    /// <returns>The reason text, or <see langword="null"/> when none was supplied.</returns>
+    /// <remarks>
+    /// The reason is what makes an ignore directive reviewable: "turn this off" is not something a
+    /// reviewer can evaluate, but "bounded provider lookup, at most three sections" is.
+    /// </remarks>
+    public static string? GetIgnoreReason(IReadOnlyList<string>? tags)
+    {
+        if (tags is null)
+        {
+            return null;
+        }
+
+        const string ReasonKey = "reason=";
+
+        for (var i = 0; i < tags.Count; i++)
+        {
+            var tag = tags[i];
+            if (!tag.StartsWith(IgnoreDirective, StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            var reasonStart = tag.IndexOf(ReasonKey, StringComparison.OrdinalIgnoreCase);
+            if (reasonStart < 0)
+            {
+                continue;
+            }
+
+            var reason = tag[(reasonStart + ReasonKey.Length)..].Trim();
+            if (reason.Length > 0)
+            {
+                return reason;
+            }
+        }
+
+        return null;
+    }
+
+    private static int Advance(int lineEnd, int length) => lineEnd < 0 ? length : lineEnd + 1;
+}

--- a/src/QueryGuard.EntityFrameworkCore/PACKAGE.md
+++ b/src/QueryGuard.EntityFrameworkCore/PACKAGE.md
@@ -1,0 +1,41 @@
+# QueryGuard.EntityFrameworkCore
+
+Captures Entity Framework Core relational commands for
+[QueryGuard.NET](https://github.com/Benziza/queryguard-dotnet), so repeated SQL can be grouped and
+query budgets can be enforced.
+
+Capture uses the official
+[EF Core interception API](https://learn.microsoft.com/ef/core/logging-events-diagnostics/interceptors).
+QueryGuard **observes only**: it never modifies the generated SQL, suppresses a command, changes a
+result, or replaces the exception your application sees.
+
+## Registering the interceptor
+
+```csharp
+builder.Services.AddDbContext<AppDbContext>((services, db) =>
+{
+    db.UseSqlite(connectionString);
+    db.AddInterceptors(services.GetRequiredService<QueryGuardCommandInterceptor>());
+});
+```
+
+Nothing is captured unless a QueryGuard scope is open — through
+`QueryGuard.AspNetCore` middleware for a request, or `QueryGuard.Testing` for a test. With no
+active scope the interceptor does no work at all.
+
+## Privacy defaults
+
+Parameter values and connection strings are never captured, literals in SQL are redacted, and
+retained samples are bounded. See
+[SECURITY.md](https://github.com/Benziza/queryguard-dotnet/blob/main/SECURITY.md).
+
+## Supported versions
+
+| Target framework | EF Core |
+| --- | --- |
+| `net8.0` | 8.0.x |
+| `net10.0` | 10.0.x |
+
+Any **relational** EF Core provider works through the interception contract. SQLite and PostgreSQL
+are integration-tested; see the
+[provider matrix](https://github.com/Benziza/queryguard-dotnet/blob/main/docs/decisions/0009-provider-matrix.md).

--- a/src/QueryGuard.EntityFrameworkCore/QueryGuard.EntityFrameworkCore.csproj
+++ b/src/QueryGuard.EntityFrameworkCore/QueryGuard.EntityFrameworkCore.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <RootNamespace>QueryGuard.EntityFrameworkCore</RootNamespace>
+    <Description>Captures Entity Framework Core relational commands through the official DbCommandInterceptor API so QueryGuard.NET can group repeated SQL and evaluate query budgets. Observes only: the generated SQL, the command result, and the original exception are never modified.</Description>
+    <PackageTags>ef-core;entity-framework-core;sql;n-plus-one;interceptor;performance</PackageTags>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../QueryGuard.Core/QueryGuard.Core.csproj" />
+  </ItemGroup>
+
+  <!--
+    EF Core is pinned per target framework in Directory.Packages.props: net8.0 resolves the
+    EF Core 8 line and net10.0 the EF Core 10 line, so a consumer never ends up with a
+    mismatched framework and EF Core pair. See docs/decisions/0008-target-frameworks.md.
+  -->
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" />
+  </ItemGroup>
+
+</Project>

--- a/src/QueryGuard.EntityFrameworkCore/QueryGuardCommandInterceptor.cs
+++ b/src/QueryGuard.EntityFrameworkCore/QueryGuardCommandInterceptor.cs
@@ -1,0 +1,255 @@
+using System;
+using System.Collections.Generic;
+using System.Data.Common;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+
+namespace QueryGuard.EntityFrameworkCore;
+
+/// <summary>
+/// Records EF Core relational command execution into the active <see cref="QueryGuardSession"/>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <strong>This interceptor observes and nothing else.</strong> It never modifies the generated SQL,
+/// suppresses a command, changes a result, or replaces the exception the application sees. Every
+/// override returns the value it was given. A diagnostics tool that changes observed behavior is
+/// worse than no tool, because it makes every subsequent debugging session start with "is this real,
+/// or is it QueryGuard?".
+/// </para>
+/// <para>
+/// EF Core registers an interceptor as a <strong>singleton</strong> per <c>DbContext</c>
+/// configuration, so one instance sees commands from every concurrent request and every parallel
+/// test. It therefore holds no per-request state: it asks
+/// <see cref="IQueryGuardSessionAccessor"/> which scope the command it is looking at belongs to.
+/// With no active scope it does no work at all. See
+/// <c>docs/decisions/0002-session-propagation.md</c>.
+/// </para>
+/// <para>
+/// Both the synchronous and asynchronous method pairs are implemented. Implementing only one would
+/// produce a tool that silently misses half of a real application's queries — and real ASP.NET Core
+/// code is overwhelmingly asynchronous.
+/// </para>
+/// </remarks>
+public sealed class QueryGuardCommandInterceptor : DbCommandInterceptor
+{
+    private readonly IQueryGuardSessionAccessor _sessionAccessor;
+    private readonly IQueryFingerprintFactory _fingerprintFactory;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="QueryGuardCommandInterceptor"/> class.
+    /// </summary>
+    /// <param name="sessionAccessor">Locates the session the current command belongs to.</param>
+    /// <param name="fingerprintFactory">Turns command text into a stable fingerprint.</param>
+    /// <exception cref="ArgumentNullException">A required argument is <see langword="null"/>.</exception>
+    public QueryGuardCommandInterceptor(
+        IQueryGuardSessionAccessor sessionAccessor,
+        IQueryFingerprintFactory fingerprintFactory)
+    {
+        ArgumentNullException.ThrowIfNull(sessionAccessor);
+        ArgumentNullException.ThrowIfNull(fingerprintFactory);
+
+        _sessionAccessor = sessionAccessor;
+        _fingerprintFactory = fingerprintFactory;
+    }
+
+    /// <inheritdoc />
+    public override DbDataReader ReaderExecuted(
+        DbCommand command,
+        CommandExecutedEventData eventData,
+        DbDataReader result)
+    {
+        Record(command, eventData, QueryCommandKind.Reader);
+        return result;
+    }
+
+    /// <inheritdoc />
+    public override ValueTask<DbDataReader> ReaderExecutedAsync(
+        DbCommand command,
+        CommandExecutedEventData eventData,
+        DbDataReader result,
+        CancellationToken cancellationToken = default)
+    {
+        Record(command, eventData, QueryCommandKind.Reader);
+        return new ValueTask<DbDataReader>(result);
+    }
+
+    /// <inheritdoc />
+    public override object? ScalarExecuted(
+        DbCommand command,
+        CommandExecutedEventData eventData,
+        object? result)
+    {
+        Record(command, eventData, QueryCommandKind.Scalar);
+        return result;
+    }
+
+    /// <inheritdoc />
+    public override ValueTask<object?> ScalarExecutedAsync(
+        DbCommand command,
+        CommandExecutedEventData eventData,
+        object? result,
+        CancellationToken cancellationToken = default)
+    {
+        Record(command, eventData, QueryCommandKind.Scalar);
+        return new ValueTask<object?>(result);
+    }
+
+    /// <inheritdoc />
+    public override int NonQueryExecuted(
+        DbCommand command,
+        CommandExecutedEventData eventData,
+        int result)
+    {
+        Record(command, eventData, QueryCommandKind.NonQuery);
+        return result;
+    }
+
+    /// <inheritdoc />
+    public override ValueTask<int> NonQueryExecutedAsync(
+        DbCommand command,
+        CommandExecutedEventData eventData,
+        int result,
+        CancellationToken cancellationToken = default)
+    {
+        Record(command, eventData, QueryCommandKind.NonQuery);
+        return new ValueTask<int>(result);
+    }
+
+    /// <inheritdoc />
+    /// <remarks>
+    /// A failed command is recorded as evidence and then EF Core continues exactly as it would
+    /// have. The original exception keeps its type, message, and stack, and QueryGuard never
+    /// becomes the thing that reports the failure.
+    /// </remarks>
+    public override void CommandFailed(DbCommand command, CommandErrorEventData eventData)
+        => RecordFailure(command, eventData);
+
+    /// <inheritdoc />
+    public override Task CommandFailedAsync(
+        DbCommand command,
+        CommandErrorEventData eventData,
+        CancellationToken cancellationToken = default)
+    {
+        RecordFailure(command, eventData);
+        return Task.CompletedTask;
+    }
+
+    private void Record(DbCommand command, CommandExecutedEventData eventData, QueryCommandKind kind)
+    {
+        var session = _sessionAccessor.Current;
+        if (session is null)
+        {
+            // No scope open means no capture. QueryGuard stays silent rather than guessing which
+            // scope a command belongs to, and this early return is the whole cost of having the
+            // interceptor registered outside a measured scope.
+            return;
+        }
+
+        Capture(
+            session,
+            command,
+            eventData.CommandSource,
+            eventData.Duration,
+            Classify(kind, command.CommandText),
+            failureType: null);
+    }
+
+    private void RecordFailure(DbCommand command, CommandErrorEventData eventData)
+    {
+        var session = _sessionAccessor.Current;
+        if (session is null)
+        {
+            return;
+        }
+
+        Capture(
+            session,
+            command,
+            eventData.CommandSource,
+            eventData.Duration,
+            // EF Core does not report which execution method was in flight when a command failed,
+            // so the statement itself is the only evidence available.
+            Classify(QueryCommandKind.Unknown, command.CommandText),
+            eventData.Exception?.GetType().FullName);
+    }
+
+    private void Capture(
+        QueryGuardSession session,
+        DbCommand command,
+        CommandSource commandSource,
+        TimeSpan duration,
+        QueryCommandKind kind,
+        string? failureType)
+    {
+        var commandText = command.CommandText;
+        var fingerprint = _fingerprintFactory.Create(commandText, kind);
+
+        session.Record(
+            kind: kind,
+            fingerprint: fingerprint,
+            // EF Core measures the command itself and hands the duration over, which is both more
+            // accurate than timing around the interceptor and free of correlation state.
+            duration: duration < TimeSpan.Zero ? TimeSpan.Zero : duration,
+            commandSource: commandSource.ToString(),
+            // The count, never the names and never the values.
+            // See docs/decisions/0004-parameter-privacy.md.
+            parameterCount: command.Parameters.Count,
+            isFailed: failureType is not null,
+            failureType: failureType,
+            tags: QueryGuardQueryTag.Extract(commandText));
+    }
+
+    /// <summary>
+    /// Decides what a command <em>does</em>, using the execution method EF Core chose and the
+    /// statement's leading keyword together.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The execution method alone is not enough, because it is provider-dependent in a way that
+    /// would quietly corrupt query budgets. On SQLite, EF Core executes
+    /// <c>INSERT … RETURNING "Id"</c> through the <em>reader</em> path so it can read the generated
+    /// key back. Trusting the method there would count every inserted row against a read budget, and
+    /// a budget of ten reads would mean something different on every provider.
+    /// </para>
+    /// <para>
+    /// So a command executed as a reader is demoted to <see cref="QueryCommandKind.NonQuery"/> when
+    /// its statement clearly modifies data. The leading keyword is the only signal needed for that —
+    /// this is not, and must not become, SQL parsing.
+    /// </para>
+    /// </remarks>
+    private static QueryCommandKind Classify(QueryCommandKind executionKind, string? commandText)
+    {
+        if (string.IsNullOrWhiteSpace(commandText))
+        {
+            return executionKind;
+        }
+
+        var isModification = IsModificationStatement(commandText);
+
+        return executionKind switch
+        {
+            // A write executed through the reader path is still a write.
+            QueryCommandKind.Reader when isModification => QueryCommandKind.NonQuery,
+
+            // A failure reports no execution method, so the statement is the only evidence.
+            QueryCommandKind.Unknown => isModification ? QueryCommandKind.NonQuery : QueryCommandKind.Reader,
+
+            _ => executionKind,
+        };
+    }
+
+    private static bool IsModificationStatement(string commandText)
+    {
+        var span = commandText.AsSpan().TrimStart();
+
+        return span.StartsWith("INSERT", StringComparison.OrdinalIgnoreCase)
+            || span.StartsWith("UPDATE", StringComparison.OrdinalIgnoreCase)
+            || span.StartsWith("DELETE", StringComparison.OrdinalIgnoreCase)
+            || span.StartsWith("MERGE", StringComparison.OrdinalIgnoreCase)
+            || span.StartsWith("CREATE", StringComparison.OrdinalIgnoreCase)
+            || span.StartsWith("ALTER", StringComparison.OrdinalIgnoreCase)
+            || span.StartsWith("DROP", StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/tests/QueryGuard.EntityFrameworkCore.Tests/QueryGuard.EntityFrameworkCore.Tests.csproj
+++ b/tests/QueryGuard.EntityFrameworkCore.Tests/QueryGuard.EntityFrameworkCore.Tests.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <RootNamespace>QueryGuard.EntityFrameworkCore.Tests</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../src/QueryGuard.EntityFrameworkCore/QueryGuard.EntityFrameworkCore.csproj" />
+  </ItemGroup>
+
+  <!-- SQLite gives real relational command execution with no container to start. -->
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" />
+  </ItemGroup>
+
+</Project>

--- a/tests/QueryGuard.EntityFrameworkCore.Tests/QueryGuardCommandInterceptorTests.cs
+++ b/tests/QueryGuard.EntityFrameworkCore.Tests/QueryGuardCommandInterceptorTests.cs
@@ -1,0 +1,393 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+
+namespace QueryGuard.EntityFrameworkCore.Tests;
+
+/// <summary>
+/// Interception behavior against real SQLite command execution.
+/// </summary>
+/// <remarks>
+/// These are integration tests on purpose. Whether a fake interceptor records what we hand it says
+/// nothing about whether EF Core calls the methods we think it calls, with the durations and command
+/// sources we think it supplies.
+/// </remarks>
+public sealed class QueryGuardCommandInterceptorTests : IDisposable
+{
+    private readonly SqliteFixture _fixture = new();
+    private readonly AsyncLocalQueryGuardSessionAccessor _accessor = new();
+    private readonly QueryGuardCommandInterceptor _interceptor;
+
+    public QueryGuardCommandInterceptorTests()
+        => _interceptor = new QueryGuardCommandInterceptor(_accessor, new QueryFingerprintFactory());
+
+    public void Dispose() => _fixture.Dispose();
+
+    [Fact]
+    public void Constructor_requires_its_collaborators()
+    {
+        Assert.Throws<ArgumentNullException>(
+            () => new QueryGuardCommandInterceptor(null!, new QueryFingerprintFactory()));
+        Assert.Throws<ArgumentNullException>(
+            () => new QueryGuardCommandInterceptor(_accessor, null!));
+    }
+
+    [Fact]
+    public void With_no_active_scope_nothing_is_captured_and_the_query_still_works()
+    {
+        // The interceptor is registered for the lifetime of the DbContext configuration, which means
+        // it observes queries outside any measured scope. Doing nothing there is the contract.
+        using var context = _fixture.CreateContext(_interceptor);
+
+        var companies = context.Companies.ToList();
+
+        Assert.NotEmpty(companies);
+        Assert.Null(_accessor.Current);
+    }
+
+    [Fact]
+    public void A_synchronous_read_produces_one_record_with_a_measured_duration()
+    {
+        var session = NewSession();
+        using var context = _fixture.CreateContext(_interceptor);
+
+        using (_accessor.Activate(session))
+        {
+            _ = context.Companies.ToList();
+        }
+
+        var completed = session.Complete();
+        var record = Assert.Single(completed.Records);
+
+        Assert.Equal(QueryCommandKind.Reader, record.Kind);
+        Assert.True(record.IsRead);
+
+        // A duration of exactly zero is possible for a fast in-memory query; a negative one would
+        // mean the measurement is wrong.
+        Assert.True(record.Duration >= TimeSpan.Zero);
+        Assert.StartsWith(QueryFingerprint.IdPrefix, record.Fingerprint.Id, StringComparison.Ordinal);
+        Assert.Contains("Companies", record.Fingerprint.NormalizedSql, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task An_asynchronous_read_produces_the_same_record_contract()
+    {
+        // Real ASP.NET Core code is overwhelmingly async. Implementing only the sync path would
+        // produce a tool that silently misses nearly everything.
+        var session = NewSession();
+        using var context = _fixture.CreateContext(_interceptor);
+
+        using (_accessor.Activate(session))
+        {
+            _ = await context.Companies.ToListAsync();
+        }
+
+        var completed = session.Complete();
+        var record = Assert.Single(completed.Records);
+
+        Assert.Equal(QueryCommandKind.Reader, record.Kind);
+        Assert.True(record.Duration >= TimeSpan.Zero);
+    }
+
+    [Fact]
+    public async Task A_scalar_query_is_recorded_as_a_scalar_command()
+    {
+        var session = NewSession();
+        using var context = _fixture.CreateContext(_interceptor);
+
+        using (_accessor.Activate(session))
+        {
+            _ = await context.Companies.CountAsync();
+        }
+
+        var completed = session.Complete();
+        var record = Assert.Single(completed.Records);
+
+        // EF Core executes COUNT through the reader path on SQLite, so this asserts the record is a
+        // read of some kind rather than pinning the exact execution method.
+        Assert.True(record.IsRead);
+    }
+
+    [Fact]
+    public async Task A_write_is_recorded_but_does_not_count_toward_a_read_budget()
+    {
+        // A budget of ten reads must mean ten reads regardless of how many entities are saved — and
+        // regardless of which execution path the provider happens to use. On SQLite, EF Core runs
+        // INSERT ... RETURNING through the reader path so it can read the generated key back, so
+        // trusting the execution method alone would count every inserted row as a read.
+        var session = NewSession();
+        using var context = _fixture.CreateContext(_interceptor);
+
+        using (_accessor.Activate(session))
+        {
+            context.Departments.Add(new Department { CompanyId = 1, Name = "Added" });
+            await context.SaveChangesAsync();
+        }
+
+        var completed = session.Complete();
+
+        Assert.NotEmpty(completed.Records);
+        Assert.All(completed.Records, record =>
+        {
+            Assert.Equal(QueryCommandKind.NonQuery, record.Kind);
+            Assert.False(record.IsRead);
+        });
+        Assert.Equal(0, completed.CountedCommandCount);
+    }
+
+    [Fact]
+    public async Task A_repeated_query_shares_one_fingerprint_despite_different_parameter_values()
+    {
+        // This is the entire product in one assertion: the same logical query executed per parent
+        // row has to land in a single group, or nothing downstream can count it.
+        var session = NewSession();
+        using var context = _fixture.CreateContext(_interceptor);
+
+        using (_accessor.Activate(session))
+        {
+            var companyIds = await context.Companies.Select(company => company.Id).ToListAsync();
+
+            foreach (var companyId in companyIds)
+            {
+                _ = await context.Departments
+                    .Where(department => department.CompanyId == companyId)
+                    .ToListAsync();
+            }
+        }
+
+        var completed = session.Complete();
+        var departmentQueries = completed.Records
+            .Where(record => record.Fingerprint.NormalizedSql.Contains("Departments", StringComparison.Ordinal))
+            .ToList();
+
+        Assert.Equal(5, departmentQueries.Count);
+        Assert.Single(departmentQueries.Select(record => record.Fingerprint.Id).Distinct());
+    }
+
+    [Fact]
+    public async Task Parameter_values_never_reach_a_record()
+    {
+        // A captured variable is what EF Core turns into a real parameter. The count is useful
+        // evidence; the names and values are not worth the risk.
+        var city = "Paris";
+        var session = NewSession();
+        using var context = _fixture.CreateContext(_interceptor);
+
+        using (_accessor.Activate(session))
+        {
+            _ = await context.Companies
+                .Where(company => company.City == city)
+                .ToListAsync();
+        }
+
+        var completed = session.Complete();
+        var record = Assert.Single(completed.Records);
+
+        Assert.DoesNotContain("Paris", record.Fingerprint.NormalizedSql, StringComparison.Ordinal);
+        Assert.True(record.ParameterCount >= 1);
+    }
+
+    [Fact]
+    public async Task An_inlined_literal_is_redacted_even_though_ef_core_did_not_parameterize_it()
+    {
+        // EF Core inlines a literal constant rather than parameterizing it, so the value lands in
+        // the command text itself. This is exactly the case where a query written one way would leak
+        // data that the same query written another way would not.
+        var session = NewSession();
+        using var context = _fixture.CreateContext(_interceptor);
+
+        using (_accessor.Activate(session))
+        {
+            _ = await context.Companies
+                .Where(company => company.City == "Paris")
+                .ToListAsync();
+        }
+
+        var record = Assert.Single(session.Complete().Records);
+
+        Assert.DoesNotContain("Paris", record.Fingerprint.NormalizedSql, StringComparison.Ordinal);
+        Assert.Contains("City", record.Fingerprint.NormalizedSql, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task The_connection_string_never_reaches_a_record()
+    {
+        var session = NewSession();
+        using var context = _fixture.CreateContext(_interceptor);
+
+        using (_accessor.Activate(session))
+        {
+            _ = await context.Companies.ToListAsync();
+        }
+
+        var completed = session.Complete();
+
+        Assert.All(completed.Records, record =>
+        {
+            Assert.DoesNotContain("Filename", record.Fingerprint.NormalizedSql, StringComparison.OrdinalIgnoreCase);
+            Assert.DoesNotContain("memory", record.Fingerprint.NormalizedSql, StringComparison.OrdinalIgnoreCase);
+        });
+    }
+
+    [Fact]
+    public async Task A_failing_command_is_recorded_and_the_original_exception_still_surfaces()
+    {
+        // QueryGuard adds diagnostics alongside a failure. It must never become the thing that
+        // reports it, or every debugging session starts by ruling QueryGuard out.
+        var session = NewSession();
+        using var context = _fixture.CreateContext(_interceptor);
+
+        var exception = await Assert.ThrowsAnyAsync<Exception>(async () =>
+        {
+            using (_accessor.Activate(session))
+            {
+                await context.Database.ExecuteSqlRawAsync("SELECT * FROM \"NoSuchTable\"");
+            }
+        });
+
+        Assert.Contains("Sqlite", exception.GetType().FullName!, StringComparison.Ordinal);
+
+        var completed = session.Complete();
+        var record = Assert.Single(completed.Records);
+
+        Assert.True(record.IsFailed);
+        Assert.Equal(1, completed.FailedCommandCount);
+        Assert.Contains("Sqlite", record.FailureType!, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task A_query_tag_is_recognized_on_the_record()
+    {
+        var session = NewSession();
+        using var context = _fixture.CreateContext(_interceptor);
+
+        using (_accessor.Activate(session))
+        {
+            _ = await context.Companies
+                .TagWith("QueryGuard:Ignore reason=bounded-reference-lookup")
+                .ToListAsync();
+        }
+
+        var completed = session.Complete();
+        var record = Assert.Single(completed.Records);
+
+        Assert.True(QueryGuardQueryTag.HasIgnoreDirective(record.Tags));
+        Assert.Equal("bounded-reference-lookup", QueryGuardQueryTag.GetIgnoreReason(record.Tags));
+    }
+
+    [Fact]
+    public async Task An_untagged_query_carries_no_tags()
+    {
+        var session = NewSession();
+        using var context = _fixture.CreateContext(_interceptor);
+
+        using (_accessor.Activate(session))
+        {
+            _ = await context.Companies.TagWith("just a note for a human").ToListAsync();
+        }
+
+        var completed = session.Complete();
+        var record = Assert.Single(completed.Records);
+
+        // An arbitrary tag is a comment like any other. QueryGuard does not retain text it was not
+        // asked to interpret.
+        Assert.Empty(record.Tags);
+    }
+
+    [Fact]
+    public async Task Two_concurrent_scopes_over_the_same_context_configuration_stay_isolated()
+    {
+        // One interceptor instance, two scopes, deliberately different query counts.
+        var busy = NewSession("busy");
+        var quiet = NewSession("quiet");
+
+        var busyTask = Task.Run(async () =>
+        {
+            using var context = _fixture.CreateContext(_interceptor);
+            using (_accessor.Activate(busy))
+            {
+                for (var i = 0; i < 4; i++)
+                {
+                    _ = await context.Companies.ToListAsync();
+                }
+            }
+        });
+
+        var quietTask = Task.Run(async () =>
+        {
+            using var context = _fixture.CreateContext(_interceptor);
+            using (_accessor.Activate(quiet))
+            {
+                _ = await context.Departments.ToListAsync();
+            }
+        });
+
+        await Task.WhenAll(busyTask, quietTask);
+
+        Assert.Equal(4, busy.Complete().Records.Count);
+        Assert.Single(quiet.Complete().Records);
+    }
+
+    [Fact]
+    public async Task The_interceptor_does_not_change_query_results()
+    {
+        // The whole promise is that installing QueryGuard does not change how the application
+        // behaves, so compare the same query with and without it.
+        using var guarded = _fixture.CreateContext(_interceptor);
+        using var plain = _fixture.CreateContext();
+
+        var session = NewSession();
+        List<Company> guardedResult;
+
+        using (_accessor.Activate(session))
+        {
+            guardedResult = await guarded.Companies.OrderBy(company => company.Id).ToListAsync();
+        }
+
+        var plainResult = await plain.Companies.OrderBy(company => company.Id).ToListAsync();
+
+        Assert.Equal(plainResult.Count, guardedResult.Count);
+        Assert.Equal(
+            plainResult.Select(company => company.Name),
+            guardedResult.Select(company => company.Name));
+        Assert.NotEmpty(session.Complete().Records);
+    }
+
+    [Fact]
+    public async Task Cancellation_still_propagates_with_the_interceptor_attached()
+    {
+        var session = NewSession();
+        using var context = _fixture.CreateContext(_interceptor);
+        using var cancellation = new CancellationTokenSource();
+        await cancellation.CancelAsync();
+
+        using (_accessor.Activate(session))
+        {
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(
+                () => context.Companies.ToListAsync(cancellation.Token));
+        }
+    }
+
+    [Fact]
+    public async Task Records_carry_the_command_source_reported_by_ef_core()
+    {
+        var session = NewSession();
+        using var context = _fixture.CreateContext(_interceptor);
+
+        using (_accessor.Activate(session))
+        {
+            _ = await context.Companies.ToListAsync();
+        }
+
+        var record = Assert.Single(session.Complete().Records);
+
+        Assert.False(string.IsNullOrWhiteSpace(record.CommandSource));
+    }
+
+    private static QueryGuardSession NewSession(string name = "GET /api/companies")
+        => new(name, QueryGuardPolicy.Create("test"));
+}

--- a/tests/QueryGuard.EntityFrameworkCore.Tests/SampleDbContext.cs
+++ b/tests/QueryGuard.EntityFrameworkCore.Tests/SampleDbContext.cs
@@ -1,0 +1,150 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Data.Sqlite;
+
+namespace QueryGuard.EntityFrameworkCore.Tests;
+
+/// <summary>
+/// A synthetic schema: companies with departments, and nothing else.
+/// </summary>
+/// <remarks>
+/// Two entities related one-to-many is the minimum needed to produce a genuine repeated-query
+/// pattern — one child query per parent row. Everything here is invented; no schema, name, or SQL in
+/// this repository comes from a real application.
+/// </remarks>
+public sealed class SampleDbContext : DbContext
+{
+    public SampleDbContext(DbContextOptions<SampleDbContext> options)
+        : base(options)
+    {
+    }
+
+    public DbSet<Company> Companies => Set<Company>();
+
+    public DbSet<Department> Departments => Set<Department>();
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        modelBuilder.Entity<Company>(entity =>
+        {
+            entity.HasKey(company => company.Id);
+            entity.Property(company => company.Name).IsRequired();
+            entity
+                .HasMany(company => company.Departments)
+                .WithOne(department => department.Company!)
+                .HasForeignKey(department => department.CompanyId);
+        });
+
+        modelBuilder.Entity<Department>(entity =>
+        {
+            entity.HasKey(department => department.Id);
+            entity.Property(department => department.Name).IsRequired();
+        });
+    }
+}
+
+public sealed class Company
+{
+    public int Id { get; set; }
+
+    public string Name { get; set; } = string.Empty;
+
+    public string City { get; set; } = string.Empty;
+
+    public ICollection<Department> Departments { get; } = [];
+}
+
+public sealed class Department
+{
+    public int Id { get; set; }
+
+    public int CompanyId { get; set; }
+
+    public string Name { get; set; } = string.Empty;
+
+    public Company? Company { get; set; }
+}
+
+/// <summary>
+/// An in-memory SQLite database that lives as long as the fixture holds its connection.
+/// </summary>
+/// <remarks>
+/// SQLite in shared-cache memory mode gives real relational command execution — real SQL generation,
+/// real parameters, real provider behavior — with no container to start and no file to clean up. The
+/// connection has to be held open, because the database ceases to exist when the last connection to
+/// it closes.
+/// </remarks>
+public sealed class SqliteFixture : IDisposable
+{
+    private readonly SqliteConnection _connection;
+    private bool _isDisposed;
+
+    public SqliteFixture(int companies = 5, int departmentsPerCompany = 3)
+    {
+        _connection = new SqliteConnection("Filename=:memory:");
+        _connection.Open();
+
+        using var context = CreateContext();
+        context.Database.EnsureCreated();
+        Seed(context, companies, departmentsPerCompany);
+    }
+
+    /// <summary>
+    /// Creates a context over the fixture's database, optionally with interceptors attached.
+    /// </summary>
+    public SampleDbContext CreateContext(params Microsoft.EntityFrameworkCore.Diagnostics.IInterceptor[] interceptors)
+    {
+        var builder = new DbContextOptionsBuilder<SampleDbContext>()
+            .UseSqlite(_connection);
+
+        if (interceptors.Length > 0)
+        {
+            builder.AddInterceptors(interceptors);
+        }
+
+        return new SampleDbContext(builder.Options);
+    }
+
+    public void Dispose()
+    {
+        if (_isDisposed)
+        {
+            return;
+        }
+
+        _isDisposed = true;
+        _connection.Dispose();
+    }
+
+    private static void Seed(SampleDbContext context, int companies, int departmentsPerCompany)
+    {
+        // Deterministic seed data, so a demo or an assertion never depends on random values.
+        for (var companyIndex = 1; companyIndex <= companies; companyIndex++)
+        {
+            var company = new Company
+            {
+                Id = companyIndex,
+                Name = string.Create(CultureInfo.InvariantCulture, $"Company {companyIndex}"),
+                City = companyIndex % 2 == 0 ? "Lyon" : "Paris",
+            };
+
+            context.Companies.Add(company);
+
+            for (var departmentIndex = 1; departmentIndex <= departmentsPerCompany; departmentIndex++)
+            {
+                context.Departments.Add(new Department
+                {
+                    Id = ((companyIndex - 1) * departmentsPerCompany) + departmentIndex,
+                    CompanyId = companyIndex,
+                    Name = string.Create(CultureInfo.InvariantCulture, $"Department {departmentIndex}"),
+                });
+            }
+        }
+
+        context.SaveChanges();
+        context.ChangeTracker.Clear();
+    }
+}

--- a/tests/QueryGuard.EntityFrameworkCore.Tests/SampleDbContext.cs
+++ b/tests/QueryGuard.EntityFrameworkCore.Tests/SampleDbContext.cs
@@ -1,9 +1,8 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
-using System.Linq;
-using Microsoft.EntityFrameworkCore;
 using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
 
 namespace QueryGuard.EntityFrameworkCore.Tests;
 
@@ -69,23 +68,39 @@ public sealed class Department
 }
 
 /// <summary>
-/// An in-memory SQLite database that lives as long as the fixture holds its connection.
+/// A real SQLite database, held in memory for the lifetime of the fixture.
 /// </summary>
 /// <remarks>
-/// SQLite in shared-cache memory mode gives real relational command execution — real SQL generation,
-/// real parameters, real provider behavior — with no container to start and no file to clean up. The
-/// connection has to be held open, because the database ceases to exist when the last connection to
-/// it closes.
+/// <para>
+/// SQLite gives real relational command execution — real SQL generation, real parameters, real
+/// provider behavior — with no container to start and no file to clean up.
+/// </para>
+/// <para>
+/// It uses a <em>named</em> shared-cache in-memory database rather than a bare <c>:memory:</c>
+/// connection, so that each context can open its own connection to the same data. Sharing a single
+/// <see cref="SqliteConnection"/> across contexts is not safe when commands run concurrently, and
+/// the concurrency tests here exist precisely to run commands concurrently. One connection is held
+/// open for the fixture's lifetime because a shared in-memory database ceases to exist when the last
+/// connection to it closes.
+/// </para>
+/// <para>
+/// The database name includes a GUID so that parallel test classes never collide.
+/// </para>
 /// </remarks>
 public sealed class SqliteFixture : IDisposable
 {
-    private readonly SqliteConnection _connection;
+    private readonly SqliteConnection _keepAlive;
+    private readonly string _connectionString;
     private bool _isDisposed;
 
     public SqliteFixture(int companies = 5, int departmentsPerCompany = 3)
     {
-        _connection = new SqliteConnection("Filename=:memory:");
-        _connection.Open();
+        _connectionString = string.Create(
+            CultureInfo.InvariantCulture,
+            $"Data Source=queryguard-{Guid.NewGuid():N};Mode=Memory;Cache=Shared");
+
+        _keepAlive = new SqliteConnection(_connectionString);
+        _keepAlive.Open();
 
         using var context = CreateContext();
         context.Database.EnsureCreated();
@@ -98,7 +113,7 @@ public sealed class SqliteFixture : IDisposable
     public SampleDbContext CreateContext(params Microsoft.EntityFrameworkCore.Diagnostics.IInterceptor[] interceptors)
     {
         var builder = new DbContextOptionsBuilder<SampleDbContext>()
-            .UseSqlite(_connection);
+            .UseSqlite(_connectionString);
 
         if (interceptors.Length > 0)
         {
@@ -116,7 +131,7 @@ public sealed class SqliteFixture : IDisposable
         }
 
         _isDisposed = true;
-        _connection.Dispose();
+        _keepAlive.Dispose();
     }
 
     private static void Seed(SampleDbContext context, int companies, int departmentsPerCompany)


### PR DESCRIPTION
## Summary

- Capture relational commands on EF Core 8 and 10.

## Checks

- Build and tests passed.

Closes QG-014, QG-015, QG-016, QG-017, QG-018
Closes #14
Closes #15
Closes #16
Closes #17
Closes #18