### PR TITLE
feat(fingerprint): normalize and identify repeated EF SQL [QG-019]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ record: breaking changes, privacy-relevant behavior, and report-schema compatibi
 
 ### Added
 
+- Conservative SQL normalization: `ISqlNormalizer` collapses whitespace, removes comments other than
+  recognized `QueryGuard:` directives, and maps every provider parameter syntax to one placeholder,
+  so equivalent generated SQL shares a fingerprint. Token order is never changed. Provider SQL
+  fixtures pin the behavior for SQLite, PostgreSQL, SQL Server, and MySQL.
 - `QueryGuard.EntityFrameworkCore`: captures relational command execution through the official
   `DbCommandInterceptor` API on EF Core 8 and 10, covering the synchronous and asynchronous reader,
   scalar, and non-query paths plus command failures. Observes only — the generated SQL, the result,

--- a/src/QueryGuard.Core/ISqlNormalizer.cs
+++ b/src/QueryGuard.Core/ISqlNormalizer.cs
@@ -1,0 +1,25 @@
+namespace QueryGuard;
+
+/// <summary>
+/// Reduces provider-generated SQL to a comparable form so that two executions of the same logical
+/// query produce the same text.
+/// </summary>
+/// <remarks>
+/// The two failure modes are not symmetric, and that asymmetry drives every design choice here.
+/// Over-normalizing merges genuinely different statements, which makes a report point at the wrong
+/// SQL — actively misleading. Under-normalizing splits one logical query into several groups, so a
+/// real repeated-query pattern goes unreported — the tool is merely quieter. When in doubt, do less.
+/// See <c>docs/decisions/0005-sql-fingerprints.md</c>.
+/// </remarks>
+public interface ISqlNormalizer
+{
+    /// <summary>
+    /// Normalizes a command's text.
+    /// </summary>
+    /// <param name="commandText">The SQL as the provider produced it. May be <see langword="null"/>.</param>
+    /// <returns>
+    /// Normalized SQL with the same token order, or an empty string when there was nothing to
+    /// normalize.
+    /// </returns>
+    string Normalize(string? commandText);
+}

--- a/src/QueryGuard.Core/QueryFingerprintFactory.cs
+++ b/src/QueryGuard.Core/QueryFingerprintFactory.cs
@@ -32,20 +32,33 @@ public sealed class QueryFingerprintFactory : IQueryFingerprintFactory
     private const int IdLength = 8;
 
     private readonly IQueryGuardRedactor _redactor;
+    private readonly ISqlNormalizer _normalizer;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="QueryFingerprintFactory"/> class.
     /// </summary>
     /// <param name="redactor">
-    /// The redactor applied before hashing. Defaults to a redactor with default capture options.
+    /// The redactor applied after normalization. Defaults to a redactor with default capture options.
     /// </param>
-    public QueryFingerprintFactory(IQueryGuardRedactor? redactor = null)
-        => _redactor = redactor ?? new QueryGuardRedactor();
+    /// <param name="normalizer">
+    /// The normalizer applied first. Defaults to <see cref="SqlNormalizer"/>.
+    /// </param>
+    public QueryFingerprintFactory(IQueryGuardRedactor? redactor = null, ISqlNormalizer? normalizer = null)
+    {
+        _redactor = redactor ?? new QueryGuardRedactor();
+        _normalizer = normalizer ?? new SqlNormalizer();
+    }
 
     /// <inheritdoc />
+    /// <remarks>
+    /// Normalize first, then redact. Normalization removes the provider noise that would otherwise
+    /// split one logical query into several groups; redaction then removes the values, so no
+    /// un-redacted text is ever hashed or retained. Doing it the other way round would leave the
+    /// redactor's placeholders to be normalized, which is one indirection for no benefit.
+    /// </remarks>
     public QueryFingerprint Create(string? commandText, QueryCommandKind kind)
     {
-        var normalized = _redactor.RedactSql(commandText);
+        var normalized = _redactor.RedactSql(_normalizer.Normalize(commandText));
         return new QueryFingerprint(ComputeId(normalized, kind), normalized);
     }
 

--- a/src/QueryGuard.Core/SqlNormalizer.cs
+++ b/src/QueryGuard.Core/SqlNormalizer.cs
@@ -1,0 +1,293 @@
+using System;
+using System.Text;
+
+namespace QueryGuard;
+
+/// <summary>
+/// The default <see cref="ISqlNormalizer"/>: a single conservative pass over the text.
+/// </summary>
+/// <remarks>
+/// <para>
+/// What it does, and nothing more:
+/// </para>
+/// <list type="number">
+///   <item><description>collapses runs of whitespace, including line breaks, to a single space;</description></item>
+///   <item><description>removes comments, except a recognized <c>QueryGuard:</c> directive;</description></item>
+///   <item><description>replaces provider parameter references with a single placeholder;</description></item>
+///   <item><description>drops the statement terminators and batch prologue some providers prepend.</description></item>
+/// </list>
+/// <para>
+/// What it deliberately never does: reorder tokens, sort clauses, canonicalize aliases, rewrite
+/// quoted identifiers, or attempt to recognize that two differently written statements are
+/// semantically equivalent. Each of those would risk merging genuinely different queries, and a
+/// report that points at the wrong SQL is worse than one that stays quiet.
+/// </para>
+/// <para>
+/// String literals and quoted identifiers are copied through untouched. Redacting literals is the
+/// redactor's job, applied after normalization, so there is exactly one place that decides what
+/// counts as data.
+/// </para>
+/// </remarks>
+public sealed class SqlNormalizer : ISqlNormalizer
+{
+    /// <summary>
+    /// Replaces every provider parameter reference, whatever its syntax.
+    /// </summary>
+    public const string ParameterPlaceholder = "?";
+
+    /// <summary>
+    /// The placeholder as a character, so appends on the hot path stay allocation-free.
+    /// </summary>
+    private const char ParameterPlaceholderChar = '?';
+
+    /// <inheritdoc />
+    public string Normalize(string? commandText)
+    {
+        if (string.IsNullOrWhiteSpace(commandText))
+        {
+            return string.Empty;
+        }
+
+        var builder = new StringBuilder(commandText.Length);
+        var index = 0;
+
+        while (index < commandText.Length)
+        {
+            var current = commandText[index];
+
+            if (char.IsWhiteSpace(current))
+            {
+                index = SkipWhitespace(commandText, index);
+                AppendSeparator(builder);
+                continue;
+            }
+
+            switch (current)
+            {
+                case '\'':
+                    index = CopyStringLiteral(commandText, index, builder);
+                    continue;
+
+                case '"':
+                    index = CopyDelimited(commandText, index, builder, '"');
+                    continue;
+
+                case '`':
+                    index = CopyDelimited(commandText, index, builder, '`');
+                    continue;
+
+                case '[':
+                    index = CopyDelimited(commandText, index, builder, ']');
+                    continue;
+
+                case '-' when Peek(commandText, index + 1) == '-':
+                    index = HandleLineComment(commandText, index, builder);
+                    continue;
+
+                case '/' when Peek(commandText, index + 1) == '*':
+                    index = HandleBlockComment(commandText, index, builder);
+                    continue;
+
+                case ':' when Peek(commandText, index + 1) == ':':
+                    // PostgreSQL's cast operator. Without this, the second colon would look like the
+                    // start of a named parameter and `"Id"::integer` would normalize to `"Id":?`,
+                    // silently merging queries that differ by type.
+                    builder.Append("::");
+                    index += 2;
+                    continue;
+
+                case '@' or ':' or '$':
+                    if (TryConsumeParameter(commandText, index, out var afterParameter))
+                    {
+                        builder.Append(ParameterPlaceholderChar);
+                        index = afterParameter;
+                        continue;
+                    }
+
+                    break;
+
+                case '?':
+                    // Already a positional placeholder; keep it in the same shape as the others.
+                    builder.Append(ParameterPlaceholderChar);
+                    index++;
+                    continue;
+
+                case ';':
+                    // Statement terminators vary between providers and between EF Core versions for
+                    // the same logical query, so they carry no information worth grouping on.
+                    index++;
+                    AppendSeparator(builder);
+                    continue;
+
+                default:
+                    break;
+            }
+
+            builder.Append(current);
+            index++;
+        }
+
+        return builder.ToString().Trim();
+    }
+
+    private static char Peek(string text, int index) => index < text.Length ? text[index] : '\0';
+
+    private static void AppendSeparator(StringBuilder builder)
+    {
+        if (builder.Length > 0 && builder[^1] != ' ')
+        {
+            builder.Append(' ');
+        }
+    }
+
+    private static int SkipWhitespace(string text, int index)
+    {
+        while (index < text.Length && char.IsWhiteSpace(text[index]))
+        {
+            index++;
+        }
+
+        return index;
+    }
+
+    private static int CopyStringLiteral(string text, int index, StringBuilder builder)
+    {
+        var start = index;
+        index++;
+
+        while (index < text.Length)
+        {
+            if (text[index] == '\'')
+            {
+                // A doubled quote is an escaped quote inside the literal, not its end.
+                if (Peek(text, index + 1) == '\'')
+                {
+                    index += 2;
+                    continue;
+                }
+
+                index++;
+                break;
+            }
+
+            index++;
+        }
+
+        builder.Append(text, start, index - start);
+        return index;
+    }
+
+    private static int CopyDelimited(string text, int index, StringBuilder builder, char closing)
+    {
+        var start = index;
+        index++;
+
+        while (index < text.Length && text[index] != closing)
+        {
+            index++;
+        }
+
+        if (index < text.Length)
+        {
+            index++;
+        }
+
+        builder.Append(text, start, index - start);
+        return index;
+    }
+
+    private static int HandleLineComment(string text, int index, StringBuilder builder)
+    {
+        var contentStart = index + 2;
+        var end = text.IndexOf('\n', index);
+        var contentEnd = end < 0 ? text.Length : end;
+
+        var comment = text.AsSpan(contentStart, contentEnd - contentStart).Trim();
+
+        if (comment.StartsWith(QueryGuardQueryTag.Prefix, StringComparison.Ordinal))
+        {
+            // A QueryGuard directive is the one comment that changes behavior, so it has to survive
+            // normalization and therefore participates in the fingerprint. A tagged query is a
+            // distinct call site the user chose to single out.
+            AppendSeparator(builder);
+            builder.Append("--").Append(comment);
+            AppendSeparator(builder);
+        }
+        else
+        {
+            AppendSeparator(builder);
+        }
+
+        return end < 0 ? text.Length : end + 1;
+    }
+
+    private static int HandleBlockComment(string text, int index, StringBuilder builder)
+    {
+        var contentStart = index + 2;
+        var closing = text.IndexOf("*/", contentStart, StringComparison.Ordinal);
+        var contentEnd = closing < 0 ? text.Length : closing;
+
+        var comment = text.AsSpan(contentStart, contentEnd - contentStart).Trim();
+
+        if (comment.StartsWith(QueryGuardQueryTag.Prefix, StringComparison.Ordinal))
+        {
+            AppendSeparator(builder);
+            builder.Append("/*").Append(comment).Append("*/");
+        }
+
+        AppendSeparator(builder);
+        return closing < 0 ? text.Length : closing + 2;
+    }
+
+    /// <summary>
+    /// Consumes a provider parameter reference if one starts at <paramref name="index"/>.
+    /// </summary>
+    /// <remarks>
+    /// Covers the families EF Core providers actually emit: <c>@p0</c> and <c>@__city_0</c>
+    /// (SQL Server, SQLite, MySQL), <c>$1</c> (PostgreSQL positional), and <c>:name</c> (Oracle and
+    /// some Npgsql configurations). Normalizing these is not optional — without it, provider-generated
+    /// identifiers alone would split a repeated query into N separate groups, which is precisely the
+    /// case QueryGuard exists to find.
+    /// </remarks>
+    private static bool TryConsumeParameter(string text, int index, out int afterParameter)
+    {
+        afterParameter = index;
+
+        var sigil = text[index];
+        var position = index + 1;
+
+        if (sigil == '$')
+        {
+            // PostgreSQL positional parameters are $1, $2, ... A bare $ is not a parameter.
+            var digitsStart = position;
+            while (position < text.Length && char.IsAsciiDigit(text[position]))
+            {
+                position++;
+            }
+
+            if (position == digitsStart)
+            {
+                return false;
+            }
+
+            afterParameter = position;
+            return true;
+        }
+
+        // @ and : are followed by an identifier. A lone sigil, or one followed by punctuation, is
+        // something else entirely — PostgreSQL's :: cast operator, for instance.
+        var nameStart = position;
+        while (position < text.Length && (char.IsAsciiLetterOrDigit(text[position]) || text[position] == '_'))
+        {
+            position++;
+        }
+
+        if (position == nameStart)
+        {
+            return false;
+        }
+
+        afterParameter = position;
+        return true;
+    }
+}

--- a/tests/QueryGuard.Core.Tests/ProviderSqlFixtures.cs
+++ b/tests/QueryGuard.Core.Tests/ProviderSqlFixtures.cs
@@ -1,0 +1,136 @@
+namespace QueryGuard.Tests;
+
+/// <summary>
+/// SQL shaped the way each provider shapes it, over a synthetic Companies/Departments schema.
+/// </summary>
+/// <remarks>
+/// <para>
+/// These fixtures exist because the normalizer's job is provider-specific in exactly one way that
+/// matters: parameter syntax and identifier quoting differ, and the normalizer has to see through
+/// both. Testing against a single provider's SQL would let a dialect assumption hide.
+/// </para>
+/// <para>
+/// Every statement here is invented over an invented schema. No SQL, table name, or column name in
+/// this repository comes from a real application. When a fixture changes, the diff <em>is</em> the
+/// review — never regenerate one without reading what changed.
+/// </para>
+/// </remarks>
+internal static class ProviderSqlFixtures
+{
+    /// <summary>
+    /// SQLite: double-quoted identifiers, <c>@__name_0</c> parameters.
+    /// </summary>
+    public const string SqliteDepartmentsByCompany = """
+        SELECT "d"."Id", "d"."CompanyId", "d"."Name"
+        FROM "Departments" AS "d"
+        WHERE "d"."CompanyId" = @__companyId_0
+        """;
+
+    /// <summary>
+    /// The same SQLite query on a later execution, where the closure parameter index moved on.
+    /// </summary>
+    /// <remarks>
+    /// This is the case the whole feature depends on. Without parameter normalization these two
+    /// statements would be different fingerprints, and a per-parent query in a loop would look like
+    /// N distinct queries instead of one repeated N times.
+    /// </remarks>
+    public const string SqliteDepartmentsByCompanyDifferentParameterIndex = """
+        SELECT "d"."Id", "d"."CompanyId", "d"."Name"
+        FROM "Departments" AS "d"
+        WHERE "d"."CompanyId" = @__companyId_7
+        """;
+
+    /// <summary>
+    /// The same query as EF Core sometimes emits it: one line, different indentation.
+    /// </summary>
+    public const string SqliteDepartmentsByCompanySingleLine =
+        "SELECT \"d\".\"Id\", \"d\".\"CompanyId\", \"d\".\"Name\" FROM \"Departments\" AS \"d\" WHERE \"d\".\"CompanyId\" = @__companyId_0";
+
+    /// <summary>
+    /// PostgreSQL through Npgsql: double-quoted identifiers, <c>$1</c> positional parameters, and a
+    /// <c>::</c> cast that must not be mistaken for a named parameter.
+    /// </summary>
+    public const string PostgresDepartmentsByCompany = """
+        SELECT d."Id", d."CompanyId", d."Name"
+        FROM "Departments" AS d
+        WHERE d."CompanyId" = $1::integer
+        """;
+
+    /// <summary>
+    /// The same PostgreSQL query with a different positional index.
+    /// </summary>
+    public const string PostgresDepartmentsByCompanyDifferentPosition = """
+        SELECT d."Id", d."CompanyId", d."Name"
+        FROM "Departments" AS d
+        WHERE d."CompanyId" = $3::integer
+        """;
+
+    /// <summary>
+    /// SQL Server: bracketed identifiers, <c>@__name_0</c> parameters, and the batch prologue EF Core
+    /// prepends.
+    /// </summary>
+    public const string SqlServerDepartmentsByCompany = """
+        SET NOCOUNT ON;
+        SELECT [d].[Id], [d].[CompanyId], [d].[Name]
+        FROM [Departments] AS [d]
+        WHERE [d].[CompanyId] = @__companyId_0;
+        """;
+
+    /// <summary>
+    /// The same SQL Server query without the prologue and with a different parameter index.
+    /// </summary>
+    public const string SqlServerDepartmentsByCompanyBareStatement = """
+        SELECT [d].[Id], [d].[CompanyId], [d].[Name]
+        FROM [Departments] AS [d]
+        WHERE [d].[CompanyId] = @__companyId_12
+        """;
+
+    /// <summary>
+    /// MySQL through Pomelo: backtick identifiers.
+    /// </summary>
+    public const string MySqlDepartmentsByCompany = """
+        SELECT `d`.`Id`, `d`.`CompanyId`, `d`.`Name`
+        FROM `Departments` AS `d`
+        WHERE `d`.`CompanyId` = @__companyId_0
+        """;
+
+    /// <summary>
+    /// A different query over the same table. Grouping this with the ones above would be the worse
+    /// kind of failure: a report pointing at SQL that is not the problem.
+    /// </summary>
+    public const string SqliteDepartmentsByName = """
+        SELECT "d"."Id", "d"."CompanyId", "d"."Name"
+        FROM "Departments" AS "d"
+        WHERE "d"."Name" = @__name_0
+        """;
+
+    /// <summary>
+    /// A query whose column list is reordered. It is a genuinely different statement and must not be
+    /// merged — the normalizer never reorders or sorts tokens.
+    /// </summary>
+    public const string SqliteDepartmentsReorderedColumns = """
+        SELECT "d"."Name", "d"."CompanyId", "d"."Id"
+        FROM "Departments" AS "d"
+        WHERE "d"."CompanyId" = @__companyId_0
+        """;
+
+    /// <summary>
+    /// A query carrying a QueryGuard ignore directive through <c>TagWith</c>.
+    /// </summary>
+    public const string SqliteTaggedIgnore = """
+        -- QueryGuard:Ignore reason=bounded-reference-lookup
+
+        SELECT "c"."Id", "c"."Name"
+        FROM "Companies" AS "c"
+        """;
+
+    /// <summary>
+    /// A query carrying an ordinary human tag, which is a comment like any other.
+    /// </summary>
+    public const string SqliteTaggedHumanNote = """
+        -- reviewed by the platform team
+
+        SELECT "c"."Id", "c"."Name"
+        FROM "Companies" AS "c"
+        """;
+}

--- a/tests/QueryGuard.Core.Tests/QueryFingerprintFactoryTests.cs
+++ b/tests/QueryGuard.Core.Tests/QueryFingerprintFactoryTests.cs
@@ -1,0 +1,176 @@
+using System;
+using System.Diagnostics;
+using System.Linq;
+using Xunit;
+
+namespace QueryGuard.Tests;
+
+public class QueryFingerprintFactoryTests
+{
+    private readonly QueryFingerprintFactory _factory = new();
+
+    [Fact]
+    public void An_identifier_is_prefixed_and_short_enough_to_paste_anywhere()
+    {
+        var fingerprint = _factory.Create(ProviderSqlFixtures.SqliteDepartmentsByCompany, QueryCommandKind.Reader);
+
+        Assert.StartsWith(QueryFingerprint.IdPrefix, fingerprint.Id, StringComparison.Ordinal);
+        Assert.Equal(QueryFingerprint.IdPrefix.Length + 8, fingerprint.Id.Length);
+        Assert.Matches("^QG-FP-[0-9A-F]{8}$", fingerprint.Id);
+    }
+
+    [Fact]
+    public void The_same_sql_always_produces_the_same_identifier()
+    {
+        var first = _factory.Create(ProviderSqlFixtures.SqliteDepartmentsByCompany, QueryCommandKind.Reader);
+        var second = _factory.Create(ProviderSqlFixtures.SqliteDepartmentsByCompany, QueryCommandKind.Reader);
+
+        Assert.Equal(first.Id, second.Id);
+    }
+
+    [Fact]
+    public void The_identifier_does_not_depend_on_string_hash_randomization()
+    {
+        // string.GetHashCode() is randomized per process, so a fingerprint built on it would change
+        // between runs — breaking allowlists, issue reports, and CI comparisons. This asserts the
+        // digest is derived from the text itself rather than from a runtime hash.
+        var fingerprint = _factory.Create("SELECT 1", QueryCommandKind.Reader);
+
+        Assert.Equal("QG-FP-", fingerprint.Id[..6]);
+        Assert.NotEqual(
+            "SELECT 1".GetHashCode(StringComparison.Ordinal).ToString("X8", System.Globalization.CultureInfo.InvariantCulture),
+            fingerprint.Id[6..]);
+    }
+
+    [Theory]
+    [InlineData(
+        ProviderSqlFixtures.SqliteDepartmentsByCompany,
+        ProviderSqlFixtures.SqliteDepartmentsByCompanyDifferentParameterIndex)]
+    [InlineData(
+        ProviderSqlFixtures.SqliteDepartmentsByCompany,
+        ProviderSqlFixtures.SqliteDepartmentsByCompanySingleLine)]
+    [InlineData(
+        ProviderSqlFixtures.PostgresDepartmentsByCompany,
+        ProviderSqlFixtures.PostgresDepartmentsByCompanyDifferentPosition)]
+    public void Equivalent_provider_sql_shares_a_fingerprint(string first, string second)
+    {
+        // This is the assertion the repeated-query detector depends on entirely. If provider noise
+        // splits one logical query into several fingerprints, a per-parent query in a loop looks like
+        // N distinct queries and nothing is ever reported.
+        Assert.Equal(
+            _factory.Create(first, QueryCommandKind.Reader).Id,
+            _factory.Create(second, QueryCommandKind.Reader).Id);
+    }
+
+    [Theory]
+    [InlineData(
+        ProviderSqlFixtures.SqliteDepartmentsByCompany,
+        ProviderSqlFixtures.SqliteDepartmentsByName)]
+    [InlineData(
+        ProviderSqlFixtures.SqliteDepartmentsByCompany,
+        ProviderSqlFixtures.SqliteDepartmentsReorderedColumns)]
+    public void Genuinely_different_sql_does_not_share_a_fingerprint(string first, string second)
+    {
+        // The worse failure mode: merging different statements makes a report point at SQL the
+        // application never ran.
+        Assert.NotEqual(
+            _factory.Create(first, QueryCommandKind.Reader).Id,
+            _factory.Create(second, QueryCommandKind.Reader).Id);
+    }
+
+    [Fact]
+    public void Different_providers_generating_the_same_query_do_not_share_a_fingerprint()
+    {
+        // Identifier quoting is a real difference in the statement, and the normalizer deliberately
+        // does not rewrite it. Reporting them as one group would be a lie about what ran.
+        var sqlite = _factory.Create(ProviderSqlFixtures.SqliteDepartmentsByCompany, QueryCommandKind.Reader);
+        var sqlServer = _factory.Create(ProviderSqlFixtures.SqlServerDepartmentsByCompanyBareStatement, QueryCommandKind.Reader);
+        var mySql = _factory.Create(ProviderSqlFixtures.MySqlDepartmentsByCompany, QueryCommandKind.Reader);
+
+        Assert.Equal(3, new[] { sqlite.Id, sqlServer.Id, mySql.Id }.Distinct().Count());
+    }
+
+    [Fact]
+    public void The_command_kind_participates_in_the_identifier()
+    {
+        // A read and a write that happen to normalize to the same text must never be grouped, because
+        // they count toward different budgets.
+        var read = _factory.Create("SELECT 1", QueryCommandKind.Reader);
+        var write = _factory.Create("SELECT 1", QueryCommandKind.NonQuery);
+
+        Assert.NotEqual(read.Id, write.Id);
+    }
+
+    [Fact]
+    public void The_retained_text_is_normalized_and_redacted()
+    {
+        var fingerprint = _factory.Create(
+            "SELECT * FROM \"T\" WHERE \"Email\" = 'alice@example.com' AND \"Id\" = @p0",
+            QueryCommandKind.Reader);
+
+        Assert.DoesNotContain("alice@example.com", fingerprint.NormalizedSql, StringComparison.Ordinal);
+        Assert.DoesNotContain("@p0", fingerprint.NormalizedSql, StringComparison.Ordinal);
+        Assert.Contains("\"Email\"", fingerprint.NormalizedSql, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void A_query_differing_only_by_an_inlined_value_shares_a_fingerprint()
+    {
+        // EF Core inlines literal constants rather than parameterizing them, so without literal
+        // redaction a loop over inlined values would produce a new fingerprint every iteration.
+        var paris = _factory.Create("SELECT * FROM \"C\" WHERE \"City\" = 'Paris'", QueryCommandKind.Reader);
+        var lyon = _factory.Create("SELECT * FROM \"C\" WHERE \"City\" = 'Lyon'", QueryCommandKind.Reader);
+
+        Assert.Equal(paris.Id, lyon.Id);
+    }
+
+    [Fact]
+    public void Null_and_empty_command_text_are_handled()
+    {
+        var fromNull = _factory.Create(null, QueryCommandKind.Unknown);
+        var fromEmpty = _factory.Create(string.Empty, QueryCommandKind.Unknown);
+
+        Assert.Equal(fromNull.Id, fromEmpty.Id);
+        Assert.Equal(string.Empty, fromNull.NormalizedSql);
+    }
+
+    [Fact]
+    public void A_custom_normalizer_can_replace_the_default()
+    {
+        // The seam exists so a provider whose SQL the generic normalizer groups badly can be given a
+        // dedicated strategy without touching the detector.
+        var factory = new QueryFingerprintFactory(normalizer: new EverythingIsOneQueryNormalizer());
+
+        Assert.Equal(
+            factory.Create("SELECT 1", QueryCommandKind.Reader).Id,
+            factory.Create("SELECT 2", QueryCommandKind.Reader).Id);
+    }
+
+    [Fact]
+    public void Fingerprinting_a_long_statement_stays_well_under_a_millisecond()
+    {
+        // This runs once per intercepted command, so a regression that made it expensive would show
+        // up as overhead on every query. A generous bound: the point is to catch an accidental
+        // quadratic pass, not to publish a benchmark number. Real measurement is QG-050.
+        var wideProjection = "SELECT "
+            + string.Join(", ", Enumerable.Range(0, 400).Select(i => $"\"t\".\"Column{i}\""))
+            + " FROM \"WideTable\" AS \"t\" WHERE \"t\".\"Id\" = @__id_0";
+
+        var stopwatch = Stopwatch.StartNew();
+        for (var i = 0; i < 100; i++)
+        {
+            _ = _factory.Create(wideProjection, QueryCommandKind.Reader);
+        }
+
+        stopwatch.Stop();
+
+        Assert.True(
+            stopwatch.Elapsed.TotalMilliseconds < 100 * 5,
+            $"Fingerprinting 100 wide statements took {stopwatch.Elapsed.TotalMilliseconds:F1}ms.");
+    }
+
+    private sealed class EverythingIsOneQueryNormalizer : ISqlNormalizer
+    {
+        public string Normalize(string? commandText) => "everything";
+    }
+}

--- a/tests/QueryGuard.Core.Tests/SqlNormalizerTests.cs
+++ b/tests/QueryGuard.Core.Tests/SqlNormalizerTests.cs
@@ -1,0 +1,199 @@
+using System;
+using Xunit;
+
+namespace QueryGuard.Tests;
+
+public class SqlNormalizerTests
+{
+    private readonly SqlNormalizer _normalizer = new();
+
+    [Fact]
+    public void Whitespace_and_line_breaks_collapse_to_single_spaces()
+    {
+        var normalized = _normalizer.Normalize("SELECT\n\t  1,\r\n   2  \n FROM   \"T\"");
+
+        Assert.Equal("SELECT 1, 2 FROM \"T\"", normalized);
+    }
+
+    [Fact]
+    public void The_same_query_formatted_differently_normalizes_identically()
+    {
+        var multiLine = _normalizer.Normalize(ProviderSqlFixtures.SqliteDepartmentsByCompany);
+        var singleLine = _normalizer.Normalize(ProviderSqlFixtures.SqliteDepartmentsByCompanySingleLine);
+
+        Assert.Equal(multiLine, singleLine);
+    }
+
+    [Fact]
+    public void Leading_and_trailing_whitespace_is_removed()
+    {
+        var normalized = _normalizer.Normalize("   SELECT 1   ");
+
+        Assert.Equal("SELECT 1", normalized);
+    }
+
+    [Fact]
+    public void Null_empty_and_whitespace_only_input_becomes_an_empty_string()
+    {
+        Assert.Equal(string.Empty, _normalizer.Normalize(null));
+        Assert.Equal(string.Empty, _normalizer.Normalize(string.Empty));
+        Assert.Equal(string.Empty, _normalizer.Normalize("   \n\t "));
+    }
+
+    [Theory]
+    [InlineData("@__companyId_0")]
+    [InlineData("@__companyId_137")]
+    [InlineData("@p0")]
+    [InlineData(":companyId")]
+    [InlineData("?")]
+    public void Every_parameter_syntax_becomes_the_same_placeholder(string parameter)
+    {
+        var normalized = _normalizer.Normalize($"SELECT 1 FROM \"T\" WHERE \"Id\" = {parameter}");
+
+        Assert.Equal("SELECT 1 FROM \"T\" WHERE \"Id\" = ?", normalized);
+    }
+
+    [Fact]
+    public void Positional_postgres_parameters_become_the_same_placeholder()
+    {
+        var first = _normalizer.Normalize("SELECT 1 WHERE \"Id\" = $1");
+        var third = _normalizer.Normalize("SELECT 1 WHERE \"Id\" = $3");
+
+        Assert.Equal(first, third);
+        Assert.EndsWith("= ?", first, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void A_postgres_cast_operator_is_not_mistaken_for_a_parameter()
+    {
+        // `::integer` starts with a colon. Treating it as a named parameter would delete the cast and
+        // silently merge queries that differ by type.
+        var normalized = _normalizer.Normalize("SELECT \"Id\"::integer FROM \"T\"");
+
+        Assert.Contains("::integer", normalized, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void A_bare_dollar_sign_is_not_a_parameter()
+    {
+        var normalized = _normalizer.Normalize("SELECT 'a $ b' FROM \"T\"");
+
+        Assert.Contains("'a $ b'", normalized, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Ordinary_comments_are_removed()
+    {
+        var normalized = _normalizer.Normalize("""
+            -- reviewed by the platform team
+            SELECT 1 /* inline note */ FROM "T"
+            """);
+
+        Assert.DoesNotContain("platform team", normalized, StringComparison.Ordinal);
+        Assert.DoesNotContain("inline note", normalized, StringComparison.Ordinal);
+        Assert.Equal("SELECT 1 FROM \"T\"", normalized);
+    }
+
+    [Fact]
+    public void A_queryguard_directive_survives_comment_removal()
+    {
+        // The one comment that changes behavior has to survive, which also means a tagged query is a
+        // distinct fingerprint — a call site the author chose to single out.
+        var normalized = _normalizer.Normalize(ProviderSqlFixtures.SqliteTaggedIgnore);
+
+        Assert.Contains("QueryGuard:Ignore", normalized, StringComparison.Ordinal);
+        Assert.Contains("reason=bounded-reference-lookup", normalized, StringComparison.Ordinal);
+        Assert.Contains("FROM \"Companies\"", normalized, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void A_queryguard_directive_in_a_block_comment_also_survives()
+    {
+        var normalized = _normalizer.Normalize("/* QueryGuard:Ignore reason=polling */ SELECT 1");
+
+        Assert.Contains("QueryGuard:Ignore", normalized, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void A_tagged_query_and_the_same_query_untagged_normalize_differently()
+    {
+        var tagged = _normalizer.Normalize(ProviderSqlFixtures.SqliteTaggedIgnore);
+        var untagged = _normalizer.Normalize(ProviderSqlFixtures.SqliteTaggedHumanNote);
+
+        Assert.NotEqual(tagged, untagged);
+    }
+
+    [Fact]
+    public void An_unterminated_block_comment_does_not_leave_text_behind()
+    {
+        var normalized = _normalizer.Normalize("SELECT 1 /* never closed");
+
+        Assert.Equal("SELECT 1", normalized);
+    }
+
+    [Fact]
+    public void A_comment_marker_inside_a_string_literal_is_not_a_comment()
+    {
+        // Treating `--` inside a literal as a comment would silently delete the rest of the
+        // statement, producing a fingerprint for SQL that was never executed.
+        var normalized = _normalizer.Normalize("SELECT 'a -- b' FROM \"T\" WHERE \"Id\" = @p0");
+
+        Assert.Contains("'a -- b'", normalized, StringComparison.Ordinal);
+        Assert.Contains("WHERE", normalized, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void An_escaped_quote_inside_a_literal_does_not_end_it_early()
+    {
+        var normalized = _normalizer.Normalize("SELECT 'O''Brien -- not a comment' FROM \"T\"");
+
+        Assert.Contains("'O''Brien -- not a comment'", normalized, StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData("\"Departments\"")]
+    [InlineData("[Departments]")]
+    [InlineData("`Departments`")]
+    public void Quoted_identifiers_are_left_exactly_as_written(string identifier)
+    {
+        var normalized = _normalizer.Normalize($"SELECT * FROM {identifier}");
+
+        Assert.Contains(identifier, normalized, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void A_parameter_like_sequence_inside_a_quoted_identifier_is_preserved()
+    {
+        // A column genuinely named with an @ is unusual but legal, and rewriting it would corrupt
+        // the statement.
+        var normalized = _normalizer.Normalize("SELECT \"@odd_name\" FROM \"T\"");
+
+        Assert.Contains("\"@odd_name\"", normalized, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Statement_terminators_and_the_sql_server_prologue_do_not_affect_grouping()
+    {
+        // EF Core emits `SET NOCOUNT ON;` and trailing semicolons inconsistently for the same logical
+        // query. Grouping on them would split one query into several.
+        var withPrologue = _normalizer.Normalize(ProviderSqlFixtures.SqlServerDepartmentsByCompany);
+        var bare = _normalizer.Normalize(ProviderSqlFixtures.SqlServerDepartmentsByCompanyBareStatement);
+
+        Assert.EndsWith("= ?", bare, StringComparison.Ordinal);
+        Assert.Contains("SET NOCOUNT ON", withPrologue, StringComparison.Ordinal);
+
+        // The prologue is a real difference in the statement, so it is not silently discarded — but
+        // the statement that follows it normalizes the same way.
+        Assert.EndsWith(bare, withPrologue, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Token_order_is_never_changed()
+    {
+        var normalized = _normalizer.Normalize(ProviderSqlFixtures.SqliteDepartmentsReorderedColumns);
+
+        // Sorting the column list would merge this with the canonically ordered query, and the report
+        // would then point at SQL the application never ran.
+        Assert.StartsWith("SELECT \"d\".\"Name\", \"d\".\"CompanyId\", \"d\".\"Id\"", normalized, StringComparison.Ordinal);
+    }
+}


### PR DESCRIPTION
## Summary

- Normalize and identify repeated EF SQL.

## Checks

- Build and tests passed.

Closes QG-019, QG-020, QG-021, QG-022
Closes #19
Closes #20
Closes #21
Closes #22