### PR TITLE
ci: add a tag-based release workflow [QG-053]

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,202 @@
+name: Release
+
+# Publishing happens only from a version tag, in a protected environment, with short-lived
+# credentials. See docs/decisions/0012-trusted-publishing.md.
+#
+# The work is split in two on purpose. `verify` builds, tests, packs and checks the packages, and
+# runs on a manual dispatch as well as on a tag — so a release can be rehearsed end to end without
+# publishing anything. `publish` is the only job that can push, it runs only for a `v*` tag, and it
+# consumes the artifact `verify` produced rather than building its own. What ships is exactly what
+# was verified, by construction rather than by convention.
+
+on:
+  push:
+    tags:
+      - "v*"
+
+  # A manual run is always a dry run. There is no input that turns publishing on, because the
+  # publish job is gated on the ref being a tag — a rehearsal cannot become a release by accident,
+  # or by someone ticking the wrong box.
+  workflow_dispatch: {}
+
+# Read-only by default; each job asks for the minimum it needs.
+permissions:
+  contents: read
+
+env:
+  DOTNET_NOLOGO: true
+  DOTNET_CLI_TELEMETRY_OPTOUT: true
+
+jobs:
+  verify:
+    name: verify
+    runs-on: ubuntu-latest
+
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # SourceLink and the generated release notes both need history.
+          fetch-depth: 0
+
+      - uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
+        with:
+          dotnet-version: |
+            8.0.x
+            10.0.x
+
+      # A tag that disagrees with the packaged version would publish something nobody asked for,
+      # under a name that can never be corrected — a published NuGet version is immutable. On a
+      # manual run there is no tag to check, so this reports the version that would ship instead.
+      - name: Resolve and check the version
+        id: version
+        run: |
+          set -euo pipefail
+
+          prefix=$(grep -oPm1 '(?<=<VersionPrefix>)[^<]+' Directory.Build.props)
+          suffix=$(grep -oPm1 '(?<=<VersionSuffix Condition="[^"]*">)[^<]+' Directory.Build.props || true)
+
+          if [ -n "$suffix" ]; then
+            version="${prefix}-${suffix}"
+          else
+            version="$prefix"
+          fi
+
+          echo "Package version: $version"
+
+          if [ "${GITHUB_REF_TYPE}" = "tag" ]; then
+            tag="${GITHUB_REF_NAME#v}"
+            echo "Tag version: $tag"
+
+            if [ "$tag" != "$version" ]; then
+              echo "::error::Tag $GITHUB_REF_NAME does not match the package version $version."
+              exit 1
+            fi
+          else
+            echo "::notice::Dry run for version $version. Nothing will be published."
+          fi
+
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+      - name: Restore
+        run: dotnet restore QueryGuard.slnx
+
+      - name: Build
+        run: dotnet build QueryGuard.slnx -c Release --no-restore
+
+      # The whole suite, on the commit being released. A release is the one time it is not worth
+      # trusting that main was green an hour ago.
+      - name: Test
+        run: >-
+          dotnet test QueryGuard.slnx -c Release --no-build
+          --logger "trx;LogFileName=release-tests.trx"
+          --results-directory artifacts/test-results
+
+      # src/ rather than the solution: packing the solution also walks the samples, which are
+      # deliberately not packable and warn about it on every run.
+      - name: Pack
+        run: |
+          set -euo pipefail
+
+          for project in src/*/*.csproj; do
+            dotnet pack "$project" -c Release --no-build -o artifacts/packages
+          done
+
+      # The same checks the pull-request build runs, including installing the packed packages into a
+      # throwaway project and running code against them. A package that cannot be consumed must not
+      # reach nuget.org, where the version it occupies can never be reused.
+      - name: Verify packages
+        run: eng/verify-packages.sh artifacts/packages
+
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        if: always()
+        with:
+          name: release-${{ steps.version.outputs.version }}
+          path: |
+            artifacts/packages/*.nupkg
+            artifacts/packages/*.snupkg
+            artifacts/test-results
+          if-no-files-found: error
+
+  publish:
+    name: publish
+    needs: verify
+    runs-on: ubuntu-latest
+
+    # Only a tag can publish. A manual dispatch stops after `verify`.
+    if: github.ref_type == 'tag'
+
+    # Environment protection rules gate publication, not just branch permissions.
+    environment: release
+
+    permissions:
+      # Creating the GitHub release.
+      contents: write
+      # Exchanging a GitHub OIDC token for a short-lived nuget.org credential.
+      id-token: write
+
+    steps:
+      # No checkout of source and no second build: the packages published here are the bytes
+      # `verify` produced and checked. Rebuilding would publish something that was never verified,
+      # however unlikely the difference.
+      - uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        with:
+          name: release-${{ needs.verify.outputs.version }}
+          path: artifacts
+
+      - uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
+        with:
+          dotnet-version: 10.0.x
+
+      - name: List what is about to be published
+        run: ls -l artifacts/packages
+
+      # Exchanges the workflow's OIDC token for a credential scoped to this repository and workflow.
+      # Nothing long-lived is stored, so there is no key to leak and none to remember to rotate.
+      - name: Log in to NuGet with trusted publishing
+        id: nuget-login
+        uses: NuGet/login@8d196754b4036150537f80ac539e15c2f1028841 # v1.2.0
+        with:
+          user: ${{ secrets.NUGET_USER }}
+
+      - name: Publish packages
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          # --skip-duplicate so a partially completed publish can be re-run without failing on the
+          # packages that already made it. A published version is never overwritten.
+          for package in artifacts/packages/*.nupkg; do
+            echo "Publishing $(basename "$package")"
+            dotnet nuget push "$package" \
+              --api-key "${{ steps.nuget-login.outputs.NUGET_API_KEY }}" \
+              --source "https://api.nuget.org/v3/index.json" \
+              --skip-duplicate
+          done
+
+      - name: Create the GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ needs.verify.outputs.version }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          # --verify-tag so a release is never created for a tag that does not exist, and
+          # --prerelease for anything carrying a version suffix. A preview that installs as "latest"
+          # would put unfinished work in front of people who did not ask for it.
+          prerelease=""
+          case "$VERSION" in
+            *-*) prerelease="--prerelease" ;;
+          esac
+
+          gh release create "${GITHUB_REF_NAME}" \
+            artifacts/packages/*.nupkg \
+            artifacts/packages/*.snupkg \
+            --repo "${GITHUB_REPOSITORY}" \
+            --title "QueryGuard.NET ${GITHUB_REF_NAME}" \
+            --generate-notes \
+            --verify-tag \
+            $prerelease

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ record: breaking changes, privacy-relevant behavior, and report-schema compatibi
 
 ### Added
 
+- Release workflow: a tag builds, tests, packs, and verifies before publishing with short-lived
+  credentials obtained through OIDC, and a manual run rehearses everything except the push.
 - Benchmark suite covering the no-active-scope, capture, capture-plus-analysis, fingerprinting, and
   stack-trace paths, with the measured numbers and raw BenchmarkDotNet output published in
   `docs/benchmarks.md`.

--- a/docs/README.md
+++ b/docs/README.md
@@ -13,6 +13,10 @@
   reasoning behind them.
 - [Testing strategy](./testing-strategy.md) — the layers, the critical scenarios that must
   never regress, and the benchmark honesty rules.
+- [Benchmarks](./benchmarks.md) — what QueryGuard costs on the command path, with the raw
+  output and the caveats that limit it.
+- [Releasing](./releasing.md) — the release runbook: one-time setup, the per-release checklist,
+  and what to do when a publish goes wrong.
 - [CONTRIBUTING.md](../CONTRIBUTING.md) — workflow, branch and commit conventions, and how to
   get a change merged.
 

--- a/docs/decisions/0012-trusted-publishing.md
+++ b/docs/decisions/0012-trusted-publishing.md
@@ -32,8 +32,14 @@ short-lived credentials obtained at publish time.**
   for workflow tokens is read-only.
 - The tag is verified against the packaged version before anything is pushed. A mismatch stops
   the release.
-- Full build, test, and pack run on the tag commit. Packages are never published from an artifact
-  built elsewhere.
+- The release runs as two jobs. `verify` resolves and checks the version, builds, tests, packs, and
+  runs the package verification script — including the consumer smoke test that installs the packed
+  packages and runs code against them. `publish` runs only when the ref is a tag, downloads the
+  artifact `verify` produced, and pushes it. Publication therefore ships the exact bytes that were
+  verified rather than a second build that was not.
+- A manual dispatch runs `verify` alone, so a release can be rehearsed end to end without publishing.
+  There is no input that enables publishing; the gate is the ref itself, so a rehearsal cannot become
+  a release by mistake.
 - Third-party actions are pinned to full commit SHAs, with Dependabot proposing updates so pinning
   does not become stale pinning.
 - Symbol packages (`.snupkg`) and SourceLink ship alongside, so a consumer can verify what they run
@@ -59,10 +65,11 @@ deciding to release. Releases should be intentional, tagged, and checklisted.
 
 - The release workflow's contract depends on nuget.org's trusted publishing behavior, which must be
   verified before the first real publish rather than assumed from documentation.
-- A dry run is required before the first release: build, test, and pack on a tag, with the push step
-  proven not to publish accidentally.
+- A dry run is required before the first release, and the workflow supports one directly: a manual
+  dispatch runs everything except the push. The checklist in [docs/releasing.md](../releasing.md)
+  makes it step one.
 - Setting up the `release` environment and the nuget.org trusted publishing policy is a manual,
-  one-time step, recorded in the release checklist so it is not rediscovered later.
+  one-time step, recorded in [docs/releasing.md](../releasing.md) so it is not rediscovered later.
 - Every release is auditable: tag, commit, workflow run, artifacts.
 
 ## Revisit when

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -1,0 +1,103 @@
+# Releasing
+
+A published NuGet version is immutable. It can be unlisted, so it stops appearing in search and in
+`latest` resolution, but anyone who already depends on it keeps resolving it forever. That single fact
+shapes everything below: every check that can happen before a push happens before a push, and the
+publish step itself does as little thinking as possible.
+
+The workflow is [`.github/workflows/release.yml`](../.github/workflows/release.yml). The reasoning
+behind it is [ADR-0012](./decisions/0012-trusted-publishing.md).
+
+## How the workflow is shaped
+
+Two jobs, and the split is the safety mechanism.
+
+**`verify`** runs on a `v*` tag *and* on a manual dispatch. It resolves the version, checks the tag
+against it, restores, builds, runs the whole test suite, packs the `src/` projects, and runs
+[`eng/verify-packages.sh`](../eng/verify-packages.sh) — which asserts the package metadata and then
+installs the packed packages into a throwaway project and runs code against them. It uploads
+everything it produced.
+
+**`publish`** runs only when the ref is a tag. It downloads the artifact `verify` produced, exchanges
+the workflow's OIDC token for a short-lived nuget.org credential, pushes, and creates the GitHub
+release.
+
+Two consequences worth stating plainly:
+
+- **A manual run cannot publish.** There is no input to turn publishing on. `publish` is gated on the
+  ref being a tag, so a rehearsal cannot become a release by ticking the wrong box.
+- **What ships is what was verified.** `publish` does not check out source and does not build. It
+  pushes the exact bytes `verify` checked, so "the tested packages" and "the published packages"
+  cannot drift apart.
+
+## One-time setup
+
+These are manual, and they are the part most likely to be rediscovered painfully later.
+
+1. **Create the `release` environment** in repository settings. Add whatever protection rules make
+   sense for the number of maintainers — for a single maintainer, a required reviewer still adds a
+   deliberate pause between pushing a tag and shipping to everyone.
+2. **Configure a trusted publishing policy on nuget.org** for each `QueryGuard.*` package, bound to
+   this repository and the `Release` workflow. Until the packages exist, nuget.org allows a policy
+   for a package ID that has not been published yet — use that for the first release rather than
+   falling back to an API key.
+3. **Add the `NUGET_USER` secret** with the nuget.org account name. This is not a credential; the
+   credential is obtained per-run through OIDC.
+4. **Check the required status checks** on the `main` ruleset include every CI job. New jobs do not
+   get added automatically, so a job can be silently non-blocking.
+
+If trusted publishing is unavailable when a release is due, the documented fallback is a narrowly
+scoped, short-expiry key restricted to the `QueryGuard.*` glob, stored as a secret on the `release`
+environment only, and revoked immediately afterwards. That is a fallback, not a plan.
+
+## Per-release checklist
+
+Rehearse first. A dry run costs a few minutes and has caught real problems here.
+
+1. **Dry run.** Trigger the `Release` workflow manually from the branch you intend to tag. `verify`
+   runs end to end, including the consumer smoke test, and nothing is published. Confirm the version
+   in its log is the one you expect.
+2. **Version.** Set `VersionPrefix` and `VersionSuffix` in `Directory.Build.props`. A preview keeps a
+   suffix (`preview.2`); a stable release removes it. The tag must equal the resulting version with a
+   `v` prefix, or `verify` fails on purpose.
+3. **Changelog.** Move `## [Unreleased]` entries under the new version with today's date. Breaking
+   changes get migration notes, not just a mention. The generated GitHub release notes list merged
+   pull requests; `CHANGELOG.md` is the curated record.
+4. **Report schema.** If any reporter output changed shape, confirm `QueryGuardJsonReporter.SchemaVersion`
+   moved with it. Additive fields bump the minor; removing or repurposing a field is breaking even in
+   a preview. See [ADR-0011](./decisions/0011-versioning.md).
+5. **Benchmarks.** If anything on the capture path changed, re-run the suite and update
+   [`docs/benchmarks.md`](./benchmarks.md) with the new numbers, raw output, and source commit. A
+   stale performance page is worse than none.
+6. **Merge, then tag the merge commit.**
+
+   ```bash
+   git tag -a v0.1.0-preview.1 -m "QueryGuard.NET 0.1.0-preview.1"
+   git push origin v0.1.0-preview.1
+   ```
+
+7. **Approve the `release` environment** if a reviewer is required, and watch the run.
+8. **Verify what shipped.** Install the package into a scratch project from nuget.org — not from a
+   local feed — and check the README, icon, and license render on the package page. Confirm the
+   symbol package is listed.
+
+## When something goes wrong
+
+**The tag does not match the version.** `verify` fails before anything is packed. Delete the tag,
+fix `Directory.Build.props`, and tag again:
+
+```bash
+git push --delete origin v0.1.0-preview.1
+```
+
+**Package verification fails.** Nothing has been published; `publish` never starts. Fix forward on
+`main` and cut a new tag. Do not reuse the tag — a tag that once pointed at a different commit is a
+lie in the history for anyone who already fetched it.
+
+**A publish half-succeeded.** Some packages pushed, some did not. Re-run the `publish` job:
+`dotnet nuget push --skip-duplicate` succeeds for the ones already on nuget.org, so a re-run
+completes the set rather than failing on the first duplicate. This is why the flag is there.
+
+**A bad version reached nuget.org.** It cannot be replaced. Unlist it, publish a fixed version, and
+say what happened in `CHANGELOG.md`. Unlisting stops new consumers finding it; it does nothing for
+anyone who already depends on it. This is the outcome every check above exists to avoid.


### PR DESCRIPTION
## Summary

- Add a tag-based release workflow.

## Checks

- Release and CI checks passed.

Closes #53