### PR TITLE
fix(efcore): stop counting SQL Server writes as reads

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -165,8 +165,11 @@ jobs:
           path: artifacts/test-results
           if-no-files-found: warn
 
-  # A second dialect, so an assumption baked into SQLite's SQL cannot pass as a general rule.
-  # Ubuntu only: this needs a Docker daemon, and the Windows runners do not offer a Linux one.
+  # PostgreSQL and SQL Server, so an assumption baked into SQLite's SQL cannot pass as a general
+  # rule. Adding SQL Server here found a shipped bug on its first run: EF Core prefixes its insert
+  # batch with SET statements, so classification read the leading keyword, saw SET, and counted every
+  # write against read budgets. Ubuntu only - this needs a Docker daemon, and the Windows runners do
+  # not offer a Linux one.
   provider-tests:
     name: provider-tests
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,35 +1,43 @@
-# Changelog
+﻿# Changelog
 
 All notable changes to QueryGuard.NET are documented here.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 While the version is below `1.0.0`, breaking changes may appear in a minor or preview
-release — every one of them is listed here with migration notes.
+release â€” every one of them is listed here with migration notes.
 
 Generated GitHub release notes list the merged pull requests. This file is the curated
 record: breaking changes, privacy-relevant behavior, and report-schema compatibility.
 
 ## [Unreleased]
 
+### Fixed
+
+- **A write was counted as a read on SQL Server.** EF Core prefixes its insert batch with
+  `SET IMPLICIT_TRANSACTIONS OFF; SET NOCOUNT ON;`, and command classification tested only the leading
+  keyword â€” so it saw `SET`, concluded the command was not a modification, and left it counted as a
+  read. Every `SaveChanges` on SQL Server consumed a read budget, which made a budget of ten reads
+  mean something different there than on SQLite. Classification now walks every statement in the
+  batch. Present in `0.1.0-preview.1`.
+- `QueryGuard.Testing` depended only on `QueryGuard.Core`, so installing it alone gave you the scope
+  and the assertions and nothing that could capture a command: a first run recorded zero queries and
+  every assertion failed for a reason unrelated to the code under test. It now depends on
+  `QueryGuard.EntityFrameworkCore`, and one package is enough.
+
 ### Added
 
+- Live SQL Server integration suite through Testcontainers, moving SQL Server from *fixture-verified*
+  to *integration-tested*. It found the classification bug above on its first run.
 - `UseQueryGuard()` on `DbContextOptionsBuilder`, so attaching QueryGuard outside a dependency
   injection container is one call instead of constructing an interceptor and matching its session
   accessor by hand. Calling it twice is a no-op rather than a double count.
 - `AsyncLocalQueryGuardSessionAccessor.Shared`, the ambient accessor both `UseQueryGuard()` and
   `QueryGuardScope.Start` default to.
 
-### Fixed
-
-- `QueryGuard.Testing` depended only on `QueryGuard.Core`, so installing it alone gave you the scope
-  and the assertions and nothing that could capture a command: a first run recorded zero queries and
-  every assertion failed for a reason unrelated to the code under test. It now depends on
-  `QueryGuard.EntityFrameworkCore`, and one package is enough.
-
 ### Removed
 
-- `docs/launch/` — the article draft, demo script, and community post drafts. They documented how the
+- `docs/launch/` â€” the article draft, demo script, and community post drafts. They documented how the
   project would be marketed, which is of no use to anyone evaluating whether to install it, and made
   the repository read as a campaign rather than a tool. Kept as local notes instead.
 
@@ -75,7 +83,7 @@ release.
   so the same package works with xUnit, NUnit, MSTest, or TUnit.
 - `QueryGuard.AspNetCore`: `AddQueryGuard` registration, `UseQueryGuard` middleware that opens a
   session per request, per-route-pattern policy resolution, and a structured summary with stable
-  event IDs. The middleware observes only — the response, its headers, and the original exception are
+  event IDs. The middleware observes only â€” the response, its headers, and the original exception are
   never modified.
 - Optional first-occurrence stack trace: off by default, bounded to one filtered trace per
   fingerprint, and framework frames removed so what remains is application code. False-positive
@@ -98,7 +106,7 @@ release.
   fixtures pin the behavior for SQLite, PostgreSQL, SQL Server, and MySQL.
 - `QueryGuard.EntityFrameworkCore`: captures relational command execution through the official
   `DbCommandInterceptor` API on EF Core 8 and 10, covering the synchronous and asynchronous reader,
-  scalar, and non-query paths plus command failures. Observes only — the generated SQL, the result,
+  scalar, and non-query paths plus command failures. Observes only â€” the generated SQL, the result,
   and the original exception are never modified.
 - `IQueryFingerprintFactory` with a stable SHA-256-derived identifier, and `QueryGuardQueryTag` for
   recognizing `QueryGuard:` directives attached with EF Core `TagWith`.
@@ -123,7 +131,7 @@ release.
 
 - The release workflow resolved the package version by parsing `Directory.Build.props` with a regex
   containing a variable-length lookbehind, which PCRE rejects. `grep` failed, a `|| true` swallowed the
-  failure, and the version silently lost its suffix — resolving `0.1.0` for a tag reading
+  failure, and the version silently lost its suffix â€” resolving `0.1.0` for a tag reading
   `0.1.0-preview.1`. The tag comparison refused to publish. The version now comes from
   `dotnet msbuild -getProperty:PackageVersion`, the same property `dotnet pack` stamps on the package,
   and a dry run validates the version it resolved instead of ignoring it.

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -39,6 +39,8 @@
   <ItemGroup Label="Provider integration dependencies (net10.0 only)">
     <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.3" />
     <PackageVersion Include="Testcontainers.PostgreSql" Version="4.14.0" />
+    <PackageVersion Include="Testcontainers.MsSql" Version="4.14.0" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="$(EntityFrameworkCoreVersion)" />
   </ItemGroup>
 
   <ItemGroup Label="Benchmark dependencies">

--- a/README.md
+++ b/README.md
@@ -218,7 +218,8 @@ Stated up front, because a tool that hides its limits gets distrusted the first 
   EF Core's official `DbCommandInterceptor`.
 - **No execution plans, no profiler UI, no hosted analytics.** It counts queries and groups SQL.
 - **It will not fix anything for you.** No automatic `Include`, no rewritten LINQ.
-- **Two providers are tested**, SQLite and PostgreSQL. Others very likely work — see
+- **Three providers are integration-tested** in CI: SQLite, PostgreSQL, and SQL Server. Others very
+  likely work — see
   [provider support](./docs/providers/README.md) for what "likely" is worth.
 - **.NET 8 and .NET 10.** .NET 9 is deliberately skipped ([ADR-0008](./docs/decisions/0008-target-frameworks.md)).
 

--- a/docs/decisions/0009-provider-matrix.md
+++ b/docs/decisions/0009-provider-matrix.md
@@ -1,4 +1,4 @@
-# ADR-0009: SQLite and PostgreSQL are integration-tested; everything else is stated honestly
+# ADR-0009: SQLite, PostgreSQL, and SQL Server are integration-tested; everything else is stated honestly
 
 - **Status:** Accepted
 - **Date:** 2026-08-19
@@ -28,7 +28,7 @@ flaky tests, and none of it moves the core product forward.
 | --- | --- | --- |
 | SQLite | Integration-tested | Real commands run in CI on Ubuntu and Windows, on both target frameworks |
 | PostgreSQL (Npgsql) | Integration-tested | Focused Testcontainers suite in CI |
-| SQL Server | Fixture-verified | Captured generated SQL pins the normalizer; no live database in CI |
+| SQL Server | Integration-tested | Real commands run in CI through Testcontainers |
 | MySQL / MariaDB | Community | No tests, no promises |
 | Other relational providers | Best effort | Works through the official interception contract |
 | Non-relational EF providers | Unsupported | `DbCommand` interception is relational only |
@@ -40,10 +40,11 @@ Rules that keep the tiers meaningful:
 - PostgreSQL exists to prove the design against a *second, genuinely different* SQL dialect —
   different parameter syntax, different quoting. One provider would have let dialect assumptions
   hide in the normalizer.
-- SQL Server gets fixtures rather than a container because its declaration blocks are the most
-  distinctive thing about its SQL, and a fixture pins that at a fraction of the CI cost.
-- The PostgreSQL suite skips itself when Docker is unavailable, so a contributor without Docker
-  is not blocked. It still runs in CI.
+- SQL Server is integration-tested because it is the provider most .NET developers evaluate first,
+  and because "probably works" was the weakest claim on this page. Adding it found a real bug on the
+  first run — see below.
+- The container-backed suites skip themselves when Docker is unavailable, so a contributor without
+  Docker is not blocked. They still run in CI.
 - The README, `SUPPORT.md`, and the package descriptions use these exact words. "Supports all
   EF Core providers" is a banned phrase.
 
@@ -57,15 +58,39 @@ conclude the tool does not work.
 there is no way to know whether the normalizer generalizes. PostgreSQL is the minimum second
 data point.
 
-**A live SQL Server container in CI.** Heavy image, slow startup, licensing considerations, for
-marginal additional signal over fixtures at this stage.
+**A live SQL Server container in CI.** ~~Heavy image, slow startup, licensing considerations, for
+marginal additional signal over fixtures at this stage.~~
+
+**Reversed.** "Marginal additional signal" was the wrong call, and the first live run proved it
+within a minute.
+
+EF Core's SQL Server insert batch does not begin with the statement that matters:
+
+```text
+SET IMPLICIT_TRANSACTIONS OFF;
+SET NOCOUNT ON;
+INSERT INTO [Departments] ([Id], [CompanyId], [Name]) VALUES (@p0, @p1, @p2);
+```
+
+Command classification tested only the leading keyword, saw `SET`, and left the command counted as a
+**read** — so every `SaveChanges` on SQL Server consumed a read budget, and a budget of ten reads meant
+something different on SQL Server than on SQLite. That had shipped in `0.1.0-preview.1`.
+
+The fixtures could not have caught it, and that is the general lesson rather than an accident of this
+particular bug: a fixture proves the normalizer still does what it did when the fixture was written. It
+cannot notice SQL that the fixture never contained, and nobody captures a fixture for a shape they did
+not know existed.
+
+The cost turned out to be smaller than assumed too — the whole provider suite, both containers, runs in
+about a minute. The licensing consideration is the developer edition the container image ships with,
+which is licensed for development and testing.
 
 ## Consequences
 
 - The provider issue form exists so users on untested providers have a real path in, and their
   synthetic SQL becomes a fixture. This is the cheapest possible way to widen coverage.
-- CI has to stay fast enough to be usable. The PostgreSQL job runs on provider-relevant changes
-  and on `main`, not on every documentation typo.
+- CI has to stay fast enough to be usable. The provider job runs both containers in about a minute,
+  which is cheap enough to run on every pull request rather than only on provider-relevant changes.
 - Container flakiness is treated as a bug in our test setup, not something to paper over with
   blind retries.
 

--- a/docs/providers/README.md
+++ b/docs/providers/README.md
@@ -14,7 +14,7 @@ is how a support matrix becomes a lie.
 | --- | --- | --- |
 | SQLite | **Integration-tested** | Real commands run in CI, on Ubuntu and Windows, on `net8.0` and `net10.0` |
 | PostgreSQL (Npgsql) | **Integration-tested** | Focused Testcontainers suite in CI |
-| SQL Server | **Fixture-verified** | Captured generated SQL pins the normalizer; no live database in CI |
+| SQL Server | **Integration-tested** | Real commands run in CI through Testcontainers |
 | MySQL / MariaDB | Community | No tests, no promises. Fingerprint quality unverified |
 | Other relational providers | Best effort | Works through the official interception contract |
 | Non-relational EF providers | **Unsupported** | `DbCommand` interception is relational only |
@@ -23,7 +23,10 @@ is how a support matrix becomes a lie.
 checked against captured SQL from that provider, but nothing live runs. See
 [ADR-0009](../decisions/0009-provider-matrix.md).
 
-## Why these two, specifically
+SQL Server was fixture-verified until a live suite was added, and the first run found a real bug — see
+[below](#what-the-live-sql-server-suite-found).
+
+## Why these three, specifically
 
 **SQLite is the workhorse.** Real relational execution, no container, fast enough to run the whole
 surface — interception, fingerprinting, budgets, middleware, failure paths — on every pull request.
@@ -34,8 +37,34 @@ normalizer indefinitely; the second data point is what makes the generic approac
 caught the case that had to be handled explicitly: PostgreSQL's `::` cast operator looks like the start of
 a named parameter, and treating it as one silently merged queries that differ by type.
 
-**SQL Server gets fixtures rather than a container** because its declaration blocks are the most
-distinctive thing about its SQL, and a fixture pins that at a fraction of the CI cost.
+**SQL Server is the provider most .NET developers check first**, so "probably works" was not a good
+enough answer for it. It also has the most distinctive generated SQL of the three — a parameter
+declaration prologue in front of the actual statement — which turned out to matter more than expected.
+
+## What the live SQL Server suite found
+
+A bug that had shipped, and that fixtures could not have caught.
+
+EF Core's insert batch on SQL Server does not begin with the interesting statement:
+
+```text
+SET IMPLICIT_TRANSACTIONS OFF;
+SET NOCOUNT ON;
+INSERT INTO [Departments] ([Id], [CompanyId], [Name]) VALUES (@p0, @p1, @p2);
+```
+
+QueryGuard decides whether a command is a read or a write from its leading keyword, because the
+execution method alone is provider-dependent — on SQLite an `INSERT … RETURNING` runs through the
+reader path. It saw `SET`, concluded "not a modification", and left the command classified as a read.
+So **every `SaveChanges` on SQL Server consumed a read budget**, and a budget of ten reads meant
+something different there than on SQLite, quietly.
+
+Classification now walks every statement in the batch rather than only the first. The shapes are pinned
+by unit tests that run without Docker, so the regression is caught on every pull request; the live suite
+is what noticed it existed.
+
+The general lesson, which is why the tier distinction is kept: a fixture proves the normalizer still
+does what it did when the fixture was written. It cannot notice SQL the fixture never contained.
 
 ## Parameter syntaxes the normalizer handles
 
@@ -68,12 +97,12 @@ than one provider.
 # SQLite only — no Docker needed
 dotnet test tests/QueryGuard.ProviderTests
 
-# With Docker running, the PostgreSQL tests execute too
+# With Docker running, the PostgreSQL and SQL Server tests execute too (about a minute)
 docker info && dotnet test tests/QueryGuard.ProviderTests
 ```
 
-The PostgreSQL tests skip themselves when no Docker daemon is reachable, with a skip reason that says so.
-A contributor without Docker gets a green run; CI runs them for real.
+The container-backed tests skip themselves when no Docker daemon is reachable, with a skip reason that
+says so. A contributor without Docker gets a green run; CI runs them for real.
 
 That skip is for an unavailable environment, not for a flaky test. A container that starts and then
 produces inconsistent results is a bug to diagnose, not to retry away.

--- a/docs/testing-strategy.md
+++ b/docs/testing-strategy.md
@@ -16,7 +16,7 @@ performance**.
 | Testing API | `QueryGuard.Testing.Tests` | Scope semantics and assertion message quality | Yes |
 | Reporter / schema | `QueryGuard.Reporting.Tests` | JSON schema, JUnit validity, log event IDs, redaction | Yes |
 | Concurrency stress | `QueryGuard.Core.Tests`, `QueryGuard.AspNetCore.Tests` | Zero cross-session leakage under parallel load | Yes |
-| Provider integration | `QueryGuard.ProviderTests` | Provider-specific SQL and capture behavior | Yes, both providers |
+| Provider integration | `QueryGuard.ProviderTests` | Provider-specific SQL and capture behavior | Yes: SQLite, PostgreSQL, SQL Server |
 | Performance | `QueryGuard.Benchmarks` | Measured hot-path cost | Smoke only |
 | Package consumer smoke | `package-validate` job | The built package really works as a package | Yes |
 

--- a/src/QueryGuard.EntityFrameworkCore/QueryGuardCommandInterceptor.cs
+++ b/src/QueryGuard.EntityFrameworkCore/QueryGuardCommandInterceptor.cs
@@ -245,16 +245,64 @@ public sealed class QueryGuardCommandInterceptor : DbCommandInterceptor
         };
     }
 
+    /// <summary>
+    /// Reports whether any statement in the batch modifies data.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Every statement, not just the first one, because a provider is free to put something else in
+    /// front of the interesting part. EF Core's SQL Server insert batch does exactly that:
+    /// </para>
+    /// <code>
+    /// SET IMPLICIT_TRANSACTIONS OFF;
+    /// SET NOCOUNT ON;
+    /// INSERT INTO [Departments] ([Id], [CompanyId], [Name]) VALUES (@p0, @p1, @p2);
+    /// </code>
+    /// <para>
+    /// Checking only the leading keyword saw <c>SET</c>, left the command classified as a read, and
+    /// so counted every <c>SaveChanges</c> on SQL Server against read budgets. A live suite caught
+    /// that; the captured fixtures could not, because they only ever contained the SQL someone
+    /// thought to capture.
+    /// </para>
+    /// <para>
+    /// This walks statements separated by <c>;</c> and tests each leading keyword. It is deliberately
+    /// not SQL parsing: no quote tracking, no nesting, no comment handling. A read batch that
+    /// genuinely contains a modification statement is a write as far as a read budget is concerned,
+    /// which is the answer this needs to give anyway.
+    /// </para>
+    /// </remarks>
     private static bool IsModificationStatement(string commandText)
     {
-        var span = commandText.AsSpan().TrimStart();
+        var remaining = commandText.AsSpan();
 
-        return span.StartsWith("INSERT", StringComparison.OrdinalIgnoreCase)
-            || span.StartsWith("UPDATE", StringComparison.OrdinalIgnoreCase)
-            || span.StartsWith("DELETE", StringComparison.OrdinalIgnoreCase)
-            || span.StartsWith("MERGE", StringComparison.OrdinalIgnoreCase)
-            || span.StartsWith("CREATE", StringComparison.OrdinalIgnoreCase)
-            || span.StartsWith("ALTER", StringComparison.OrdinalIgnoreCase)
-            || span.StartsWith("DROP", StringComparison.OrdinalIgnoreCase);
+        while (!remaining.IsEmpty)
+        {
+            var end = remaining.IndexOf(';');
+            var statement = (end < 0 ? remaining : remaining[..end]).TrimStart();
+
+            if (StartsWithModificationKeyword(statement))
+            {
+                return true;
+            }
+
+            if (end < 0)
+            {
+                return false;
+            }
+
+            remaining = remaining[(end + 1)..];
+        }
+
+        return false;
     }
+
+    private static bool StartsWithModificationKeyword(ReadOnlySpan<char> statement)
+        => statement.StartsWith("INSERT", StringComparison.OrdinalIgnoreCase)
+            || statement.StartsWith("UPDATE", StringComparison.OrdinalIgnoreCase)
+            || statement.StartsWith("DELETE", StringComparison.OrdinalIgnoreCase)
+            || statement.StartsWith("MERGE", StringComparison.OrdinalIgnoreCase)
+            || statement.StartsWith("CREATE", StringComparison.OrdinalIgnoreCase)
+            || statement.StartsWith("ALTER", StringComparison.OrdinalIgnoreCase)
+            || statement.StartsWith("DROP", StringComparison.OrdinalIgnoreCase)
+            || statement.StartsWith("TRUNCATE", StringComparison.OrdinalIgnoreCase);
 }

--- a/tests/QueryGuard.EntityFrameworkCore.Tests/CommandClassificationTests.cs
+++ b/tests/QueryGuard.EntityFrameworkCore.Tests/CommandClassificationTests.cs
@@ -1,0 +1,99 @@
+using System.Threading.Tasks;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using QueryGuard.Testing;
+using Xunit;
+
+namespace QueryGuard.EntityFrameworkCore.Tests;
+
+/// <summary>
+/// What a command <em>does</em>, when the provider puts something in front of the statement.
+/// </summary>
+/// <remarks>
+/// <para>
+/// These exist because of a bug the SQL Server suite found. EF Core's insert batch on SQL Server
+/// begins with directives rather than with the interesting statement:
+/// </para>
+/// <code>
+/// SET IMPLICIT_TRANSACTIONS OFF;
+/// SET NOCOUNT ON;
+/// INSERT INTO [Departments] ([Id], [CompanyId], [Name]) VALUES (@p0, @p1, @p2);
+/// </code>
+/// <para>
+/// Classification tested only the leading keyword, saw <c>SET</c>, and left the command counted as a
+/// read — so every <c>SaveChanges</c> on SQL Server consumed a read budget. The captured fixtures
+/// could not notice, because a fixture only contains SQL somebody thought to capture.
+/// </para>
+/// <para>
+/// A live SQL Server container is the only thing that finds this class of defect, and it is also too
+/// slow and too Docker-dependent to be the only guard. So the shapes live here as well, driven
+/// through the real interceptor against SQLite, where they run on every pull request in under a
+/// second.
+/// </para>
+/// </remarks>
+public class CommandClassificationTests
+{
+    [Theory]
+    // The SQL Server insert batch, verbatim in shape.
+    [InlineData("SET IMPLICIT_TRANSACTIONS OFF;\nSET NOCOUNT ON;\nINSERT INTO [T] ([A]) VALUES (@p0);")]
+    [InlineData("SET NOCOUNT ON;\nUPDATE [T] SET [A] = @p0 WHERE [Id] = @p1;\nSELECT @@ROWCOUNT;")]
+    [InlineData("SET NOCOUNT ON;\nDELETE FROM [T] WHERE [Id] = @p0;")]
+    // SQLite's generated-key form, which was the original reason classification exists.
+    [InlineData("INSERT INTO \"T\" (\"A\") VALUES (@p0) RETURNING \"Id\";")]
+    // A leading declaration, which SQL Server emits when an insert needs an OUTPUT table.
+    [InlineData("DECLARE @inserted0 TABLE ([Id] int);\nINSERT INTO [T] ([A]) OUTPUT INSERTED.[Id] INTO @inserted0 VALUES (@p0);")]
+    public async Task A_write_behind_a_directive_prologue_is_not_a_read(string commandText)
+    {
+        var record = await ExecuteAsync(commandText, expectSuccess: false);
+
+        Assert.False(record.IsRead);
+    }
+
+    [Theory]
+    [InlineData("SELECT [A] FROM [T] WHERE [Id] = @p0;")]
+    [InlineData("SET NOCOUNT ON;\nSELECT [A] FROM [T];")]
+    public async Task A_read_stays_a_read(string commandText)
+    {
+        var record = await ExecuteAsync(commandText, expectSuccess: false);
+
+        Assert.True(record.IsRead);
+    }
+
+    /// <summary>
+    /// Pushes raw SQL through the real interceptor and returns the single record it captured.
+    /// </summary>
+    /// <remarks>
+    /// The statements reference tables that do not exist, so every one of them fails. That is fine and
+    /// deliberate: a failed command is still recorded, and classification is the thing under test —
+    /// not whether SQLite can run SQL Server's syntax. It also exercises the failure path, where EF
+    /// Core reports no execution method and the statement is the only evidence available.
+    /// </remarks>
+    private static async Task<QueryRecord> ExecuteAsync(string commandText, bool expectSuccess)
+    {
+        using var connection = new SqliteConnection("Data Source=:memory:");
+        await connection.OpenAsync();
+
+        var options = new DbContextOptionsBuilder<SampleDbContext>()
+            .UseSqlite(connection)
+            .UseQueryGuard()
+            .Options;
+
+        await using var scope = QueryGuardScope.Start("classification", QueryGuardPolicy.Create("p"));
+
+        using (var db = new SampleDbContext(options))
+        {
+            try
+            {
+                _ = await db.Database.ExecuteSqlRawAsync(commandText);
+            }
+            catch (SqliteException) when (!expectSuccess)
+            {
+                // Expected: the statement is here for its shape, not to run.
+            }
+        }
+
+        var completed = await scope.CompleteAsync();
+
+        return Assert.Single(completed.Records);
+    }
+}

--- a/tests/QueryGuard.ProviderTests/QueryGuard.ProviderTests.csproj
+++ b/tests/QueryGuard.ProviderTests/QueryGuard.ProviderTests.csproj
@@ -4,6 +4,14 @@
     <RootNamespace>QueryGuard.ProviderTests</RootNamespace>
 
     <!--
+      Microsoft.Data.SqlClient throws NotSupportedException on startup under invariant globalization,
+      which this repository turns on solution-wide. The setting is there so tests cannot accidentally
+      depend on the host culture; SQL Server support is worth the exception, and every assertion in
+      this project already passes an explicit StringComparison or CultureInfo.
+    -->
+    <InvariantGlobalization>false</InvariantGlobalization>
+
+    <!--
       PostgreSQL through Testcontainers needs a Docker daemon and the Npgsql provider, neither of which
       is worth multi-targeting for. The provider behaviour under test is EF Core's SQL generation, and
       that does not differ per consumer framework.
@@ -19,7 +27,9 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" />
     <PackageReference Include="Testcontainers.PostgreSql" />
+    <PackageReference Include="Testcontainers.MsSql" />
   </ItemGroup>
 
 </Project>

--- a/tests/QueryGuard.ProviderTests/SqlServerProviderTests.cs
+++ b/tests/QueryGuard.ProviderTests/SqlServerProviderTests.cs
@@ -1,0 +1,276 @@
+using System;
+using System.Globalization;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using QueryGuard.EntityFrameworkCore;
+using Testcontainers.MsSql;
+using Xunit;
+
+namespace QueryGuard.ProviderTests;
+
+/// <summary>
+/// QueryGuard against a real SQL Server instance.
+/// </summary>
+/// <remarks>
+/// <para>
+/// SQL Server was the one provider most .NET developers would check first and the one this project
+/// could only claim as "fixture-verified" — the normalizer was pinned against captured SQL with
+/// nothing live behind it. A fixture proves the normalizer still does what it did when the fixture was
+/// written; it cannot notice that the provider now emits something the fixture never contained.
+/// </para>
+/// <para>
+/// The distinctive thing about SQL Server's generated SQL is the parameter declaration prologue:
+/// </para>
+/// <code>
+/// @__p_0 int
+/// SELECT ... WHERE [d].[CompanyId] = @__p_0
+/// </code>
+/// <para>
+/// That prologue changes with the parameter's value and type, so a normalizer that failed to strip it
+/// would produce a different fingerprint per execution — and a per-parent query in a loop would look
+/// like N distinct queries, which is precisely the case QueryGuard exists to catch. This suite runs
+/// that loop against a real server rather than trusting the fixture.
+/// </para>
+/// <para>
+/// See <c>docs/decisions/0009-provider-matrix.md</c>.
+/// </para>
+/// </remarks>
+public sealed class SqlServerProviderTests : IAsyncLifetime
+{
+    private readonly MsSqlContainer _container =
+        new MsSqlBuilder("mcr.microsoft.com/mssql/server:2022-latest").Build();
+
+    private readonly AsyncLocalQueryGuardSessionAccessor _accessor = new();
+
+    private bool _started;
+
+    public async Task InitializeAsync()
+    {
+        if (!DockerAvailability.IsAvailable)
+        {
+            return;
+        }
+
+        await _container.StartAsync();
+        _started = true;
+
+        await using var context = CreateContext();
+        await context.Database.EnsureCreatedAsync();
+        await SeedAsync(context);
+    }
+
+    public async Task DisposeAsync()
+    {
+        if (_started)
+        {
+            await _container.DisposeAsync();
+        }
+    }
+
+    [DockerFact]
+    public async Task A_repeated_query_shares_one_fingerprint_despite_the_declaration_prologue()
+    {
+        // The claim the whole product rests on, restated for SQL Server. If the prologue survived
+        // normalization this would report six fingerprints instead of one, and an N+1 in a loop would
+        // be invisible.
+        await using var context = CreateContext();
+        var session = NewSession();
+
+        using (_accessor.Activate(session))
+        {
+            var ids = await context.Companies.Select(company => company.Id).ToListAsync();
+
+            foreach (var id in ids)
+            {
+                _ = await context.Departments
+                    .Where(department => department.CompanyId == id)
+                    .ToListAsync();
+            }
+        }
+
+        var completed = session.Complete();
+        var departmentQueries = completed.Records
+            .Where(record => record.Fingerprint.NormalizedSql.Contains("Departments", StringComparison.Ordinal))
+            .ToList();
+
+        Assert.Equal(6, departmentQueries.Count);
+        Assert.Single(departmentQueries.Select(record => record.Fingerprint.Id).Distinct());
+    }
+
+    [DockerFact]
+    public async Task The_fingerprint_matches_what_the_captured_fixture_pinned()
+    {
+        // The point of running live: the fixture in QueryGuard.Core.Tests was captured by hand, and
+        // this is the only thing that can notice the provider drifting away from it. Comparing the
+        // normalized text rather than the hash keeps the failure readable when it does drift.
+        await using var context = CreateContext();
+        var session = NewSession();
+
+        using (_accessor.Activate(session))
+        {
+            _ = await context.Departments
+                .Where(department => department.CompanyId == 1)
+                .ToListAsync();
+        }
+
+        var normalized = Assert.Single(session.Complete().Records).Fingerprint.NormalizedSql;
+
+        Assert.DoesNotContain("@__", normalized, StringComparison.Ordinal);
+        Assert.DoesNotContain("declare", normalized, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("[Departments]", normalized, StringComparison.Ordinal);
+        Assert.Contains("?", normalized, StringComparison.Ordinal);
+    }
+
+    [DockerFact]
+    public async Task Bracket_quoted_identifiers_are_left_alone()
+    {
+        // Identifier quoting is structure, not data. Rewriting [Departments] to "Departments" would
+        // make the report show SQL the application never ran, so a SQL Server fingerprint is
+        // deliberately not interchangeable with a PostgreSQL one.
+        await using var context = CreateContext();
+        var session = NewSession();
+
+        using (_accessor.Activate(session))
+        {
+            _ = await context.Companies.ToListAsync();
+        }
+
+        var normalized = Assert.Single(session.Complete().Records).Fingerprint.NormalizedSql;
+
+        Assert.Contains("[Companies]", normalized, StringComparison.Ordinal);
+        Assert.DoesNotContain("\"Companies\"", normalized, StringComparison.Ordinal);
+    }
+
+    [DockerFact]
+    public async Task Two_different_queries_do_not_share_a_fingerprint()
+    {
+        await using var context = CreateContext();
+        var session = NewSession();
+
+        using (_accessor.Activate(session))
+        {
+            _ = await context.Companies.ToListAsync();
+            _ = await context.Departments.ToListAsync();
+        }
+
+        var completed = session.Complete();
+
+        Assert.Equal(2, completed.Records.Select(record => record.Fingerprint.Id).Distinct().Count());
+    }
+
+    [DockerFact]
+    public async Task An_inlined_literal_is_redacted_in_sql_server_sql()
+    {
+        await using var context = CreateContext();
+        var session = NewSession();
+
+        using (_accessor.Activate(session))
+        {
+            _ = await context.Companies.Where(company => company.City == "Paris").ToListAsync();
+        }
+
+        var record = Assert.Single(session.Complete().Records);
+
+        Assert.DoesNotContain("Paris", record.Fingerprint.NormalizedSql, StringComparison.Ordinal);
+        Assert.Contains("City", record.Fingerprint.NormalizedSql, StringComparison.Ordinal);
+    }
+
+    [DockerFact]
+    public async Task A_write_is_not_counted_as_a_read_on_sql_server()
+    {
+        // SQL Server returns generated keys through a SELECT after the INSERT, so the command that
+        // carries the write can arrive on the reader path. Counting it as a read would make a budget
+        // of ten reads mean something different here than on SQLite.
+        await using var context = CreateContext();
+        var session = NewSession();
+
+        using (_accessor.Activate(session))
+        {
+            context.Departments.Add(new Department { Id = 100, CompanyId = 1, Name = "Added" });
+            await context.SaveChangesAsync();
+        }
+
+        var completed = session.Complete();
+
+        Assert.NotEmpty(completed.Records);
+        Assert.All(completed.Records, record => Assert.False(record.IsRead));
+        Assert.Equal(0, completed.CountedCommandCount);
+    }
+
+    [DockerFact]
+    public async Task A_failing_command_is_recorded_and_the_sql_server_exception_still_surfaces()
+    {
+        await using var context = CreateContext();
+        var session = NewSession();
+
+        var exception = await Assert.ThrowsAnyAsync<Exception>(async () =>
+        {
+            using (_accessor.Activate(session))
+            {
+                await context.Database.ExecuteSqlRawAsync("SELECT * FROM [NoSuchTable]");
+            }
+        });
+
+        Assert.Contains("Sql", exception.GetType().FullName!, StringComparison.Ordinal);
+
+        var record = Assert.Single(session.Complete().Records);
+        Assert.True(record.IsFailed);
+        Assert.Contains("Sql", record.FailureType!, StringComparison.Ordinal);
+    }
+
+    [DockerFact]
+    public async Task A_query_tag_survives_sql_server_sql_generation()
+    {
+        await using var context = CreateContext();
+        var session = NewSession();
+
+        using (_accessor.Activate(session))
+        {
+            _ = await context.Companies
+                .TagWith("QueryGuard:Ignore reason=bounded-reference-lookup")
+                .ToListAsync();
+        }
+
+        var record = Assert.Single(session.Complete().Records);
+
+        Assert.True(QueryGuardQueryTag.HasIgnoreDirective(record.Tags));
+        Assert.Equal("bounded-reference-lookup", QueryGuardQueryTag.GetIgnoreReason(record.Tags));
+    }
+
+    private static QueryGuardSession NewSession()
+        => new("provider-test", QueryGuardPolicy.Create("provider"));
+
+    private ProviderDbContext CreateContext()
+    {
+        var options = new DbContextOptionsBuilder<ProviderDbContext>()
+            .UseSqlServer(_container.GetConnectionString())
+            .UseQueryGuard(_accessor)
+            .Options;
+
+        return new ProviderDbContext(options);
+    }
+
+    private static async Task SeedAsync(ProviderDbContext context)
+    {
+        for (var companyIndex = 1; companyIndex <= 6; companyIndex++)
+        {
+            context.Companies.Add(new Company
+            {
+                Id = companyIndex,
+                Name = string.Create(CultureInfo.InvariantCulture, $"Company {companyIndex}"),
+                City = companyIndex % 2 == 0 ? "Lyon" : "Paris",
+            });
+
+            context.Departments.Add(new Department
+            {
+                Id = companyIndex,
+                CompanyId = companyIndex,
+                Name = "Engineering",
+            });
+        }
+
+        await context.SaveChangesAsync();
+        context.ChangeTracker.Clear();
+    }
+}


### PR DESCRIPTION
## Summary

- Stop counting SQL Server writes as reads.

## Checks

- Build and tests passed.