### PR TITLE
fix: remove the byte-order mark from CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-﻿# Changelog
+# Changelog
 
 All notable changes to QueryGuard.NET are documented here.
 


### PR DESCRIPTION
## Summary

- Remove the byte-order mark from CHANGELOG.md.

## Checks

- Documentation checks passed.