### PR TITLE
docs: point package metadata at the documentation site

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ record: breaking changes, privacy-relevant behavior, and report-schema compatibi
   from the XML documentation — roughly 330 pages that were previously only readable as source comments.
   Built on every pull request that touches it with warnings promoted to errors, so a dead link fails the
   pull request that introduced it rather than the deployment after it merged.
+- Package metadata points at the site. `PackageProjectUrl` is now the documentation site rather than a
+  second link to the repository, which nuget.org already shows separately as the source repository, so a
+  consumer gets both instead of the same destination twice.
 
 ### Fixed
 

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -16,7 +16,9 @@
 
     <!-- Package identity and discoverability. -->
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <PackageProjectUrl>https://github.com/Benziza/queryguard-dotnet</PackageProjectUrl>
+    <!-- The documentation site rather than the repository: nuget.org renders this as "Project website"
+         and RepositoryUrl separately as "Source repository", so a consumer gets both. -->
+    <PackageProjectUrl>https://benziza.github.io/queryguard-dotnet/</PackageProjectUrl>
     <PackageReadmeFile>PACKAGE.md</PackageReadmeFile>
     <PackageIcon>queryguard-icon.png</PackageIcon>
     <PackageReleaseNotes>See https://github.com/Benziza/queryguard-dotnet/blob/main/CHANGELOG.md</PackageReleaseNotes>

--- a/src/QueryGuard.AspNetCore/PACKAGE.md
+++ b/src/QueryGuard.AspNetCore/PACKAGE.md
@@ -39,7 +39,7 @@ your application produces and the exception it raises are exactly what a client 
 enabled or disabled. Findings go to `ILogger` with stable event IDs.
 
 That is a deliberate constraint, not a missing feature — see
-[ADR-0006](https://github.com/Benziza/queryguard-dotnet/blob/main/docs/decisions/0006-aspnet-observe-only.md).
+[ADR-0006](https://benziza.github.io/queryguard-dotnet/decisions/0006-aspnet-observe-only.html).
 
 ## Policies are per route pattern
 

--- a/src/QueryGuard.Cli/PACKAGE.md
+++ b/src/QueryGuard.Cli/PACKAGE.md
@@ -87,7 +87,7 @@ a sticky pull request comment:
 ```
 
 Full documentation:
-[docs/baselines](https://github.com/Benziza/queryguard-dotnet/blob/main/docs/baselines/README.md).
+[docs/baselines](https://benziza.github.io/queryguard-dotnet/baselines/README.html).
 
 ## Preview
 

--- a/src/QueryGuard.EntityFrameworkCore/PACKAGE.md
+++ b/src/QueryGuard.EntityFrameworkCore/PACKAGE.md
@@ -47,5 +47,5 @@ Any **relational** EF Core provider works through the interception contract, so 
 captured and grouped. Whether your provider's SQL formatting produces equally good fingerprint
 *grouping* is a separate claim: SQLite and PostgreSQL are integration-tested in CI, SQL Server is
 verified against captured SQL fixtures, and everything else is unverified. The
-[provider matrix](https://github.com/Benziza/queryguard-dotnet/blob/main/docs/providers/README.md)
+[provider matrix](https://benziza.github.io/queryguard-dotnet/providers/README.html)
 keeps those tiers apart rather than blurring them.

--- a/src/QueryGuard.Reporting/PACKAGE.md
+++ b/src/QueryGuard.Reporting/PACKAGE.md
@@ -21,7 +21,7 @@ await new QueryGuardJUnitReporter().WriteAsync(result, "artifacts/queryguard.jun
 Two runs over the same result produce byte-identical output, so a snapshot test on it is meaningful.
 JSON carries an explicit `schemaVersion`: additive fields bump the minor version, and removing or
 repurposing a field is a breaking change even in a preview. See
-[ADR-0011](https://github.com/Benziza/queryguard-dotnet/blob/main/docs/decisions/0011-versioning.md).
+[ADR-0011](https://benziza.github.io/queryguard-dotnet/decisions/0011-versioning.html).
 
 ## Redaction cannot be bypassed
 

--- a/src/QueryGuard.Testing/PACKAGE.md
+++ b/src/QueryGuard.Testing/PACKAGE.md
@@ -48,7 +48,7 @@ accessor: services.GetRequiredService<IQueryGuardSessionAccessor>()
 With `WebApplicationFactory` there is one more thing to know: `TestServer` does not flow
 `ExecutionContext` into requests unless asked, and QueryGuard finds the active session through
 `AsyncLocal`. See
-[troubleshooting](https://github.com/Benziza/queryguard-dotnet/blob/main/docs/troubleshooting/README.md).
+[troubleshooting](https://benziza.github.io/queryguard-dotnet/troubleshooting/README.html).
 
 ## No test framework dependency
 
@@ -60,7 +60,7 @@ drag a framework into your project.
 Because there is no framework-native formatting to lean on, the exception message carries the evidence:
 the policy, expected against actual, the top repeated fingerprint with its redacted SQL, any ignored
 findings, and where to read about false positives. See
-[ADR-0010](https://github.com/Benziza/queryguard-dotnet/blob/main/docs/decisions/0010-testing-api.md).
+[ADR-0010](https://benziza.github.io/queryguard-dotnet/decisions/0010-testing-api.html).
 
 Prefer your own assertions? `CompleteAsync` returns the `QueryGuardResult`; assert on it however you like.
 


### PR DESCRIPTION
## Summary

- Point package metadata at the documentation site.

## Checks

- Documentation checks passed.