### PR TITLE
fix(docs): constrain the navbar logo size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@ record: breaking changes, privacy-relevant behavior, and report-schema compatibi
 
 ## [Unreleased]
 
+### Fixed
+
+- The documentation site rendered the navbar logo at its natural 128px inside a 60px navbar, so it
+  spilled out over the header on every page. The asset declares its size intrinsically, which is what
+  makes the plain `<img>` in `README.md` size correctly on GitHub, and the DocFX template sets no
+  `max-height`. Constrained by a template overlay rather than by stripping the dimensions off the SVG.
+
 ## [0.1.0-preview.4] - 2026-08-20
 
 Findings reach the places people already look: a documentation site, GitHub code scanning, and a fourth

--- a/docs/docfx.json
+++ b/docs/docfx.json
@@ -46,7 +46,8 @@
     "output": "_site",
     "template": [
       "default",
-      "modern"
+      "modern",
+      "template"
     ],
     "globalMetadata": {
       "_appName": "QueryGuard.NET",

--- a/docs/template/public/main.css
+++ b/docs/template/public/main.css
@@ -1,0 +1,23 @@
+/*
+ * Site overrides for the DocFX modern template.
+ *
+ * Loaded because "template" in docfx.json lists this folder after "default" and "modern"; DocFX applies
+ * them in order, so anything here wins.
+ */
+
+/*
+ * Constrain the navbar logo.
+ *
+ * The asset declares width="128" height="128" intrinsically, which is what makes the plain <img> in
+ * README.md size correctly on GitHub. The modern template sets no max-height on it, so the site rendered
+ * it at its natural 128px inside a 60px navbar and it spilled over the header.
+ *
+ * Sized here rather than by stripping the dimensions from the SVG: without them the README image and the
+ * social preview lose their intrinsic size too, and an unconstrained SVG in a flex container is a worse
+ * default than a fixed one.
+ */
+.navbar-brand > img {
+  height: 2rem;
+  width: auto;
+  max-height: 2rem;
+}


### PR DESCRIPTION
## Summary

- Constrain the navbar logo size.

## Checks

- Documentation checks passed.