### PR TITLE
docs: make WebApplicationFactory the main quick start

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -34,3 +34,7 @@ changelog:
       labels:
         - "type:chore"
         - "dependencies"
+
+    - title: "Other changes"
+      labels:
+        - "*"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -182,26 +182,21 @@ jobs:
         with:
           summary-path: artifacts/queryguard/summary.md
 
-      # The other half of the dogfooding: the sample tests also write a SARIF file, and uploading it
-      # puts the sample's deliberate N+1 in this repository's own Security tab, annotated on the line
-      # of samples/QueryGuard.SampleApi/Program.cs that runs the query.
+      # The other half of the dogfooding: the sample tests also write a SARIF file. Uploading it on a
+      # pull request proves that GitHub accepts the document and resolves the application location.
       #
       # This is the only check that a SARIF document is not merely valid. GitHub rejects a malformed
       # upload, so it validates the schema, and the resulting alert shows whether the location
       # actually resolved: a file can parse, upload, and annotate nothing.
       #
-      # Ubuntu only, and never from a fork: an upload needs security-events: write, which a pull
-      # request from a fork does not get, and a step that fails for a permission it was never going
-      # to have is noise rather than a signal.
-      #
-      # The event_name guard is load-bearing. On a push there is no pull_request in the payload, so
-      # comparing head.repo against the repository compares an empty string and skips - which would
-      # mean main, the branch whose alerts persist, never uploaded anything.
+      # Ubuntu only, on same-repository pull requests. A fork does not receive security-events: write.
+      # Main is excluded because the sample findings are deliberate. Leaving them open on the default
+      # branch makes the repository look as if it has unresolved security findings.
       - name: Upload the QueryGuard SARIF report
         if: >-
           matrix.os == 'ubuntu-latest'
-          && (github.event_name != 'pull_request'
-              || github.event.pull_request.head.repo.full_name == github.repository)
+          && github.event_name == 'pull_request'
+          && github.event.pull_request.head.repo.full_name == github.repository
         uses: github/codeql-action/upload-sarif@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
         with:
           sarif_file: artifacts/queryguard/queryguard.sarif

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,16 @@ record: breaking changes, privacy-relevant behavior, and report-schema compatibi
 
 ## [Unreleased]
 
+### Changed
+
+- The main quick start now uses `QueryGuard.AspNetCore.Testing`, and the sample request tests exercise
+  the same `TrackQueries` path that new users are asked to copy.
+- A testing guide separates `WebApplicationFactory` requests from explicit service and background-job
+  scopes.
+- Generated release notes include unlabeled pull requests instead of producing an empty release body.
+- The sample SARIF report is uploaded on pull requests only, so deliberate demo findings do not remain
+  open on the default branch.
+
 ## [0.1.0-preview.5] - 2026-08-21
 
 Testing and reporting are easier to adopt in ASP.NET Core applications and GitHub workflows.

--- a/README.md
+++ b/README.md
@@ -38,36 +38,42 @@ visible with a written reason.
 
 ## Quick start
 
-Install the test package:
+For an ASP.NET Core integration test, install the WebApplicationFactory helper:
 
 ```bash
-dotnet add package QueryGuard.Testing --prerelease
+dotnet add package QueryGuard.AspNetCore.Testing --prerelease
 ```
 
-Attach QueryGuard where the context is configured:
+Open a measurement, run the request, and assert the result:
 
 ```csharp
-options.UseSqlite(connectionString).UseQueryGuard();
-```
-
-Open a scope, run the request, and assert the result:
-
-```csharp
-await using var scope = QueryGuardScope.Start(
+using var factory = new WebApplicationFactory<Program>();
+await using var guard = factory.TrackQueries<Program, AppDbContext>(
     "GET /api/companies",
     QueryGuardPolicy.Create("companies")
         .WithMaxOccurrencesPerFingerprint(5));
 
-await client.GetAsync("/api/companies");
+var response = await guard.Client.GetAsync("/api/companies");
+response.EnsureSuccessStatusCode();
 
-QueryGuardAssert.Passes(await scope.CompleteAsync());
+QueryGuardAssert.Passes(await guard.CompleteAsync());
 ```
 
-`QueryGuard.Testing` brings the EF Core integration with it and has no test framework dependency.
-It works with xUnit, NUnit, MSTest, and TUnit.
+The helper attaches QueryGuard to `AppDbContext`, preserves the test execution context, and prevents
+request middleware from opening a second scope. It has no test framework dependency, so it works with
+xUnit, NUnit, MSTest, and TUnit.
 
-Use `QueryGuard.AspNetCore` for request middleware. Use `QueryGuard.Reporting` for console, JSON,
-JUnit, Markdown, and SARIF output.
+Testing a service or background job without `WebApplicationFactory`? Install `QueryGuard.Testing`,
+attach `.UseQueryGuard()` where the context is configured, and open an explicit `QueryGuardScope`.
+See the [testing guide](./docs/testing/README.md) for both paths.
+
+| Package | Use it for |
+| --- | --- |
+| `QueryGuard.AspNetCore.Testing` | Measuring real `WebApplicationFactory` requests |
+| `QueryGuard.Testing` | Explicit scopes and assertions around services or jobs |
+| `QueryGuard.AspNetCore` | Request middleware and route policies |
+| `QueryGuard.Reporting` | Console, JSON, JUnit, Markdown, and SARIF output |
+| `QueryGuard.Cli` | Recording and checking baselines in CI |
 
 ## Useful failures
 
@@ -152,6 +158,7 @@ Full documentation and the generated API reference are available at
 | Guide | Covers |
 | --- | --- |
 | [How it works](./docs/concepts/README.md) | Sessions, fingerprints, redaction, analysis |
+| [Testing](./docs/testing/README.md) | WebApplicationFactory requests and explicit scopes |
 | [Configuration](./docs/configuration/README.md) | Budgets and defaults |
 | [Baselines](./docs/baselines/README.md) | Recording and comparing query behavior |
 | [Troubleshooting](./docs/troubleshooting/README.md) | Missing capture, grouping, middleware order |

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,6 +4,8 @@
 
 - [How it works](./concepts/README.md): sessions, the stateless interceptor, fingerprints, redaction,
   and analysis, in the order a command travels through them.
+- [Testing](./testing/README.md): measure `WebApplicationFactory` requests or open an explicit scope
+  around a service or background job.
 - [Configuration](./configuration/README.md): every budget and option, what it defaults to, and the
   reasoning behind each default.
 - [Baselines](./baselines/README.md): record what a scope costs today and report what changed, so

--- a/docs/index.md
+++ b/docs/index.md
@@ -20,34 +20,30 @@ into something a test can fail on.
 ## Install
 
 ```bash
-dotnet add package QueryGuard.Testing --prerelease
+dotnet add package QueryGuard.AspNetCore.Testing --prerelease
 ```
 
-One package for testing: it brings the EF Core interceptor with it.
+This package measures real `WebApplicationFactory` requests and works with any test framework.
 
-## Two lines of setup
+## Measure one request
 
-Attach QueryGuard where the context is configured:
-
-```csharp
-options.UseSqlite(connectionString).UseQueryGuard();
-```
-
-Then assert:
+Open a measurement for the application's EF Core context:
 
 ```csharp
-await using var scope = QueryGuardScope.Start(
+using var factory = new WebApplicationFactory<Program>();
+await using var guard = factory.TrackQueries<Program, AppDbContext>(
     "GET /api/companies",
     QueryGuardPolicy.Create("companies").WithMaxOccurrencesPerFingerprint(5));
 
-await client.GetAsync("/api/companies");
+var response = await guard.Client.GetAsync("/api/companies");
+response.EnsureSuccessStatusCode();
 
-QueryGuardAssert.Passes(await scope.CompleteAsync());
+QueryGuardAssert.Passes(await guard.CompleteAsync());
 ```
 
-Outside a scope nothing is captured, so leaving the call in place costs about a nanosecond per command
-and no allocation. `QueryGuard.Testing` references no test framework, so xUnit, NUnit, MSTest, and TUnit
-all work unchanged.
+The helper attaches QueryGuard, preserves the execution context used by `TestServer`, and prevents the
+request middleware from hiding the test scope. Outside a scope nothing is captured. See the
+[testing guide](testing/README.md) for service tests, background jobs, and manual scopes.
 
 ## What a failure tells you
 
@@ -97,6 +93,7 @@ The action posts that table as a sticky pull request comment. See [baselines](ba
 | | |
 | --- | --- |
 | [How it works](concepts/README.md) | Sessions, fingerprints, redaction, analysis |
+| [Testing](testing/README.md) | WebApplicationFactory requests and explicit scopes |
 | [Configuration](configuration/README.md) | Every budget and option, and why each default is what it is |
 | [Baselines](baselines/README.md) | Recording what a scope costs and reporting what changed |
 | [Provider support](providers/README.md) | What is integration-tested and what is merely captured |

--- a/docs/testing/README.md
+++ b/docs/testing/README.md
@@ -1,0 +1,102 @@
+# Testing with QueryGuard
+
+QueryGuard can measure a real ASP.NET Core request or a smaller block of application code. Both paths
+produce the same `QueryGuardResult` and use the same assertions.
+
+## ASP.NET Core integration tests
+
+Install the helper package:
+
+```bash
+dotnet add package QueryGuard.AspNetCore.Testing --prerelease
+```
+
+Measure a request made through `WebApplicationFactory`:
+
+```csharp
+using Microsoft.AspNetCore.Mvc.Testing;
+using QueryGuard.AspNetCore.Testing;
+using QueryGuard.Testing;
+
+using var factory = new WebApplicationFactory<Program>();
+await using var guard = factory.TrackQueries<Program, AppDbContext>(
+    "GET /api/companies",
+    QueryGuardPolicy.Create("companies")
+        .WithMaxOccurrencesPerFingerprint(5));
+
+var response = await guard.Client.GetAsync("/api/companies");
+response.EnsureSuccessStatusCode();
+
+var result = await guard.CompleteAsync();
+QueryGuardAssert.Passes(result);
+```
+
+`TrackQueries` handles the setup that is easy to miss in an integration test:
+
+- it attaches QueryGuard to the selected `DbContext`
+- it sets `TestServerOptions.PreserveExecutionContext`
+- it uses the session accessor from the hosted application
+- it disables QueryGuard request middleware for the measurement, so there is only one active scope
+- it avoids adding the interceptor twice when the application already uses QueryGuard
+
+Use the client exposed by `guard`. A client created directly from the original factory does not use the
+configured test host.
+
+If the application uses more than one context, choose the context whose commands the test should
+measure. Open separate measurements when a test needs separate budgets for separate contexts.
+
+## Services and background jobs
+
+Install the general testing package:
+
+```bash
+dotnet add package QueryGuard.Testing --prerelease
+```
+
+Attach QueryGuard when the context is configured:
+
+```csharp
+options.UseSqlite(connectionString).UseQueryGuard();
+```
+
+Then open a scope around the code under test:
+
+```csharp
+await using var scope = QueryGuardScope.Start(
+    "refresh company summary",
+    QueryGuardPolicy.Create("company-summary")
+        .WithMaxQueries(3)
+        .WithMaxOccurrencesPerFingerprint(1));
+
+await service.RefreshCompanySummaryAsync();
+
+var result = await scope.CompleteAsync();
+QueryGuardAssert.Passes(result);
+```
+
+`QueryGuard.Testing` brings the EF Core integration with it. It does not reference xUnit, NUnit,
+MSTest, or TUnit.
+
+## Start with a baseline when the budget is unknown
+
+A new test often has no agreed query budget. Record the current result first and compare later runs:
+
+```csharp
+var baseline = QueryGuardBaseline.FromJson(await File.ReadAllTextAsync("queryguard-baseline.json"));
+var comparison = QueryGuardBaselineComparison.Compare(baseline, [result]);
+
+Assert.Empty(comparison.Regressions);
+```
+
+See [baselines](../baselines/README.md) for recording the file and publishing the comparison in CI.
+
+## Common failures
+
+| Symptom | Check |
+| --- | --- |
+| Zero commands from a `WebApplicationFactory` request | Use `TrackQueries` and its `Client` |
+| Twice the expected command count | Do not run request middleware inside an explicit test measurement |
+| Commands appear in the wrong scope | Complete one measurement before opening the next one |
+| The test passes but the report is missing in CI | Write reports to a path anchored at the repository root |
+
+See [troubleshooting](../troubleshooting/README.md) for manual session wiring and lower-level details.

--- a/docs/toc.yml
+++ b/docs/toc.yml
@@ -4,6 +4,8 @@
   items:
     - name: How it works
       href: concepts/README.md
+    - name: Testing
+      href: testing/README.md
     - name: Configuration
       href: configuration/README.md
     - name: Baselines

--- a/samples/QueryGuard.SampleTests/CompanyEndpointDemoTests.cs
+++ b/samples/QueryGuard.SampleTests/CompanyEndpointDemoTests.cs
@@ -13,6 +13,7 @@ using Microsoft.Data.Sqlite;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using QueryGuard.AspNetCore;
+using QueryGuard.AspNetCore.Testing;
 using QueryGuard.Reporting;
 using QueryGuard.SampleApi;
 using QueryGuard.Testing;
@@ -51,14 +52,11 @@ public sealed class CompanyEndpointDemoTests : IClassFixture<SampleApiFactory>
     [Fact]
     public async Task The_problem_endpoint_returns_200_OK_and_still_breaks_its_query_budget()
     {
-        using var client = _factory.CreateClient();
-
-        await using var scope = QueryGuardScope.Start(
+        await using var guard = _factory.TrackQueries<Program, CatalogDbContext>(
             "GET /api/companies",
-            QueryGuardPolicy.Create("companies").WithMaxOccurrencesPerFingerprint(5),
-            accessor: _factory.SessionAccessor);
+            QueryGuardPolicy.Create("companies").WithMaxOccurrencesPerFingerprint(5));
 
-        var response = await client.GetAsync(new Uri("/api/companies", UriKind.Relative));
+        var response = await guard.Client.GetAsync(new Uri("/api/companies", UriKind.Relative));
         var payload = await response.Content.ReadFromJsonAsync<List<CompanySummary>>();
 
         // Nothing about the response is wrong. That is the whole point.
@@ -66,7 +64,7 @@ public sealed class CompanyEndpointDemoTests : IClassFixture<SampleApiFactory>
         Assert.Equal(SeededCompanies, payload!.Count);
         Assert.All(payload, company => Assert.Equal(3, company.DepartmentCount));
 
-        var result = await scope.CompleteAsync();
+        var result = await guard.CompleteAsync();
         _output.WriteLine(new QueryGuardConsoleReporter().Render(result));
 
         // One query for the list, then one per company.
@@ -87,23 +85,20 @@ public sealed class CompanyEndpointDemoTests : IClassFixture<SampleApiFactory>
     [Fact]
     public async Task The_fixed_endpoint_returns_the_same_data_from_one_query()
     {
-        using var client = _factory.CreateClient();
-
-        await using var scope = QueryGuardScope.Start(
+        await using var guard = _factory.TrackQueries<Program, CatalogDbContext>(
             "GET /api/companies/projected",
             QueryGuardPolicy.Create("companies")
                 .WithMaxQueries(3)
-                .WithMaxOccurrencesPerFingerprint(1),
-            accessor: _factory.SessionAccessor);
+                .WithMaxOccurrencesPerFingerprint(1));
 
-        var response = await client.GetAsync(new Uri("/api/companies/projected", UriKind.Relative));
+        var response = await guard.Client.GetAsync(new Uri("/api/companies/projected", UriKind.Relative));
         var payload = await response.Content.ReadFromJsonAsync<List<CompanySummary>>();
 
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
         Assert.Equal(SeededCompanies, payload!.Count);
         Assert.All(payload, company => Assert.Equal(3, company.DepartmentCount));
 
-        var result = await scope.CompleteAsync();
+        var result = await guard.CompleteAsync();
         _output.WriteLine(new QueryGuardConsoleReporter().Render(result));
 
         Assert.Equal(1, result.ReadCommandCount);
@@ -134,18 +129,15 @@ public sealed class CompanyEndpointDemoTests : IClassFixture<SampleApiFactory>
     {
         // Three lookups, bounded by the shape of the report rather than by the number of rows. The tag
         // documents that next to the query, and the finding stays visible with its reason.
-        using var client = _factory.CreateClient();
-
-        await using var scope = QueryGuardScope.Start(
+        await using var guard = _factory.TrackQueries<Program, CatalogDbContext>(
             "GET /api/reports/summary",
-            QueryGuardPolicy.Create("reports").WithMaxOccurrencesPerFingerprint(1),
-            accessor: _factory.SessionAccessor);
+            QueryGuardPolicy.Create("reports").WithMaxOccurrencesPerFingerprint(1));
 
-        var response = await client.GetAsync(new Uri("/api/reports/summary", UriKind.Relative));
+        var response = await guard.Client.GetAsync(new Uri("/api/reports/summary", UriKind.Relative));
 
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
-        var result = await scope.CompleteAsync();
+        var result = await guard.CompleteAsync();
         _output.WriteLine(new QueryGuardConsoleReporter().Render(result));
 
         Assert.All(result.Findings, finding => Assert.True(finding.IsIgnored));
@@ -162,16 +154,13 @@ public sealed class CompanyEndpointDemoTests : IClassFixture<SampleApiFactory>
     public async Task The_json_and_junit_reports_render_the_failing_run()
     {
         // What a CI job would upload as an artifact.
-        using var client = _factory.CreateClient();
-
-        await using var scope = QueryGuardScope.Start(
+        await using var guard = _factory.TrackQueries<Program, CatalogDbContext>(
             "GET /api/companies",
-            QueryGuardPolicy.Create("companies").WithMaxOccurrencesPerFingerprint(5),
-            accessor: _factory.SessionAccessor);
+            QueryGuardPolicy.Create("companies").WithMaxOccurrencesPerFingerprint(5));
 
-        _ = await client.GetAsync(new Uri("/api/companies", UriKind.Relative));
+        _ = await guard.Client.GetAsync(new Uri("/api/companies", UriKind.Relative));
 
-        var result = await scope.CompleteAsync();
+        var result = await guard.CompleteAsync();
 
         var json = new QueryGuardJsonReporter().Render(result);
         var junit = new QueryGuardJUnitReporter().Render(result);
@@ -189,16 +178,13 @@ public sealed class CompanyEndpointDemoTests : IClassFixture<SampleApiFactory>
         // real findings on every pull request rather than only against fixtures. A document can be valid
         // SARIF, upload without complaint, and still annotate nothing: the assertion that matters is
         // that a location survived all the way to the emitted URI.
-        using var client = _factory.CreateClient();
-
-        await using var scope = QueryGuardScope.Start(
+        await using var guard = _factory.TrackQueries<Program, CatalogDbContext>(
             "GET /api/companies",
-            QueryGuardPolicy.Create("companies").WithMaxOccurrencesPerFingerprint(5),
-            accessor: _factory.SessionAccessor);
+            QueryGuardPolicy.Create("companies").WithMaxOccurrencesPerFingerprint(5));
 
-        _ = await client.GetAsync(new Uri("/api/companies", UriKind.Relative));
+        _ = await guard.Client.GetAsync(new Uri("/api/companies", UriKind.Relative));
 
-        var result = await scope.CompleteAsync();
+        var result = await guard.CompleteAsync();
         var root = RepositoryRoot();
         // The fallback is where a finding with no captured origin is attached. GitHub rejects a whole
         // SARIF file if any result has no location, so the choice is a real one rather than cosmetic:

--- a/samples/QueryGuard.SampleTests/QueryGuard.SampleTests.csproj
+++ b/samples/QueryGuard.SampleTests/QueryGuard.SampleTests.csproj
@@ -7,6 +7,7 @@
 
   <ItemGroup>
     <ProjectReference Include="../QueryGuard.SampleApi/QueryGuard.SampleApi.csproj" />
+    <ProjectReference Include="../../src/QueryGuard.AspNetCore.Testing/QueryGuard.AspNetCore.Testing.csproj" />
     <ProjectReference Include="../../src/QueryGuard.Testing/QueryGuard.Testing.csproj" />
     <ProjectReference Include="../../src/QueryGuard.Reporting/QueryGuard.Reporting.csproj" />
   </ItemGroup>

--- a/samples/README.md
+++ b/samples/README.md
@@ -5,7 +5,7 @@ Two projects, one point: the same endpoint, once with a hidden N+1 and once with
 | Project | What it is |
 | --- | --- |
 | `QueryGuard.SampleApi` | A minimal ASP.NET Core API over a synthetic company catalogue, wired up with QueryGuard |
-| `QueryGuard.SampleTests` | The same endpoints under `QueryGuard.Testing`, showing the assertions you would write for real |
+| `QueryGuard.SampleTests` | The same endpoints under `QueryGuard.AspNetCore.Testing`, showing the assertions you would write for real |
 
 Everything here is invented. No schema, name, or SQL in this repository comes from a real application.
 
@@ -75,7 +75,18 @@ asserts exactly that.
 dotnet test samples/QueryGuard.SampleTests
 ```
 
-Five tests, written to be read:
+The request tests use the same helper shown in the main README:
+
+```csharp
+await using var guard = factory.TrackQueries<Program, CatalogDbContext>(
+    "GET /api/companies",
+    QueryGuardPolicy.Create("companies").WithMaxOccurrencesPerFingerprint(5));
+
+var response = await guard.Client.GetAsync("/api/companies");
+var result = await guard.CompleteAsync();
+```
+
+The main scenarios are written to be read:
 
 - `The_problem_endpoint_returns_200_OK_and_still_breaks_its_query_budget`: asserts that the budget
   failure *does* happen, and prints the failure message a developer would actually see. A passing test
@@ -86,6 +97,10 @@ Five tests, written to be read:
   to be cheaper.
 - `An_intentional_repetition_is_reported_as_ignored_with_its_reason`.
 - `The_json_and_junit_reports_render_the_failing_run`: what a CI job would upload as an artifact.
+- `The_sarif_report_points_code_scanning_at_the_line_that_ran_the_query`: what a code-scanning upload
+  needs to annotate the application line.
+
+`BaselineComparisonDemoTests` measures all three endpoints and checks the committed baseline.
 
 ## Two setup details worth copying
 
@@ -93,12 +108,10 @@ Five tests, written to be read:
 pattern, so calling it earlier puts every request into a single unmatched scope. QueryGuard still works;
 the reports just lose the one label that makes them useful.
 
-**With `WebApplicationFactory`, set `TestServerOptions.PreserveExecutionContext`.** `TestServer` does not
-flow `ExecutionContext` into the request pipeline by default, and QueryGuard finds the active session
-through `AsyncLocal`. Without it, a scope opened in a test is invisible to the interceptor running inside
-the request: the scope completes with zero commands, and an assertion about query counts fails for a
-reason that has nothing to do with query counts. `SampleApiFactory` shows the one-line fix, and explains
-why setting `Server.PreserveExecutionContext` *after* `CreateClient()` is too late.
+**Use `TrackQueries` and the client it returns with `WebApplicationFactory`.** The helper preserves the
+execution context, disables request middleware for that measurement, attaches the interceptor, and uses
+the hosted application's session accessor. `BaselineComparisonDemoTests` keeps the manual setup as an
+advanced example for measuring several requests with one client.
 
 ## Where the data lives
 


### PR DESCRIPTION
## Summary

- Make the WebApplicationFactory helper the main quick start.
- Add a testing guide and use the helper in the sample request tests.
- Keep deliberate sample findings off the default branch.
- Include unlabeled pull requests in generated release notes.

## Checks

- Build passed with 0 warnings and 0 errors.
- 512 tests passed and 25 provider tests were skipped locally.
- Documentation built with 0 warnings and 0 errors.