### PR TITLE
fix(packaging): lower framework dependency floors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ record: breaking changes, privacy-relevant behavior, and report-schema compatibi
 
 ### Changed
 
+- Package dependencies now start at the first secure EF Core and ASP.NET Core 8 patch, or at 10.0.0,
+  instead of requiring the latest patch installed in this repository.
 - The main quick start now uses `QueryGuard.AspNetCore.Testing`, and the sample request tests exercise
   the same `TrackQueries` path that new users are asked to copy.
 - A testing guide separates `WebApplicationFactory` requests from explicit service and background-job

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,21 +3,36 @@
   <!--
     Central package version management.
 
-    Entity Framework Core and the Microsoft.Extensions.* abstractions are pinned per
-    target framework so that a net8.0 consumer resolves the EF Core 8 line and a
-    net10.0 consumer resolves the EF Core 10 line. See docs/decisions/0008-target-frameworks.md.
+    Product dependencies use the first patch in each supported major line. This keeps
+    the package compatible with applications that update patches on their own schedule.
+    Tests and samples use current patch versions.
+    See docs/decisions/0008-target-frameworks.md.
   -->
 
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-    <EntityFrameworkCoreVersion Condition="'$(TargetFramework)' == 'net8.0'">8.0.30</EntityFrameworkCoreVersion>
+    <EntityFrameworkCoreVersion Condition="'$(IsPackable)' == 'true' and '$(TargetFramework)' == 'net8.0'">8.0.1</EntityFrameworkCoreVersion>
+    <EntityFrameworkCoreVersion Condition="'$(IsPackable)' == 'true' and '$(EntityFrameworkCoreVersion)' == ''">10.0.0</EntityFrameworkCoreVersion>
+    <EntityFrameworkCoreVersion Condition="'$(TargetFramework)' == 'net8.0' and '$(EntityFrameworkCoreVersion)' == ''">8.0.30</EntityFrameworkCoreVersion>
     <EntityFrameworkCoreVersion Condition="'$(EntityFrameworkCoreVersion)' == ''">10.0.11</EntityFrameworkCoreVersion>
-    <MicrosoftExtensionsVersion Condition="'$(TargetFramework)' == 'net8.0'">8.0.2</MicrosoftExtensionsVersion>
+
+    <MicrosoftExtensionsVersion Condition="'$(IsPackable)' == 'true' and '$(TargetFramework)' == 'net8.0'">8.0.2</MicrosoftExtensionsVersion>
+    <MicrosoftExtensionsVersion Condition="'$(IsPackable)' == 'true' and '$(MicrosoftExtensionsVersion)' == ''">10.0.0</MicrosoftExtensionsVersion>
+    <MicrosoftExtensionsVersion Condition="'$(TargetFramework)' == 'net8.0' and '$(MicrosoftExtensionsVersion)' == ''">8.0.2</MicrosoftExtensionsVersion>
     <MicrosoftExtensionsVersion Condition="'$(MicrosoftExtensionsVersion)' == ''">10.0.11</MicrosoftExtensionsVersion>
-    <MicrosoftExtensionsLoggingVersion Condition="'$(TargetFramework)' == 'net8.0'">8.0.3</MicrosoftExtensionsLoggingVersion>
+
+    <MicrosoftExtensionsLoggingVersion Condition="'$(IsPackable)' == 'true' and '$(TargetFramework)' == 'net8.0'">8.0.2</MicrosoftExtensionsLoggingVersion>
+    <MicrosoftExtensionsLoggingVersion Condition="'$(IsPackable)' == 'true' and '$(MicrosoftExtensionsLoggingVersion)' == ''">10.0.0</MicrosoftExtensionsLoggingVersion>
+    <MicrosoftExtensionsLoggingVersion Condition="'$(TargetFramework)' == 'net8.0' and '$(MicrosoftExtensionsLoggingVersion)' == ''">8.0.3</MicrosoftExtensionsLoggingVersion>
     <MicrosoftExtensionsLoggingVersion Condition="'$(MicrosoftExtensionsLoggingVersion)' == ''">10.0.11</MicrosoftExtensionsLoggingVersion>
-    <AspNetCoreTestingVersion Condition="'$(TargetFramework)' == 'net8.0'">8.0.30</AspNetCoreTestingVersion>
+
+    <AspNetCoreTestingVersion Condition="'$(IsPackable)' == 'true' and '$(TargetFramework)' == 'net8.0'">8.0.1</AspNetCoreTestingVersion>
+    <AspNetCoreTestingVersion Condition="'$(IsPackable)' == 'true' and '$(AspNetCoreTestingVersion)' == ''">10.0.0</AspNetCoreTestingVersion>
+    <AspNetCoreTestingVersion Condition="'$(TargetFramework)' == 'net8.0' and '$(AspNetCoreTestingVersion)' == ''">8.0.30</AspNetCoreTestingVersion>
     <AspNetCoreTestingVersion Condition="'$(AspNetCoreTestingVersion)' == ''">10.0.11</AspNetCoreTestingVersion>
+
+    <CachingMemoryVersion Condition="'$(TargetFramework)' == 'net8.0'">8.0.1</CachingMemoryVersion>
+    <CachingMemoryVersion Condition="'$(CachingMemoryVersion)' == ''">$(MicrosoftExtensionsVersion)</CachingMemoryVersion>
   </PropertyGroup>
 
   <ItemGroup Label="Product dependencies">
@@ -25,6 +40,7 @@
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="$(MicrosoftExtensionsLoggingVersion)" />
     <PackageVersion Include="Microsoft.Extensions.Options" Version="$(MicrosoftExtensionsVersion)" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="$(MicrosoftExtensionsVersion)" />
+    <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="$(CachingMemoryVersion)" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="$(AspNetCoreTestingVersion)" />
   </ItemGroup>
 
@@ -34,6 +50,7 @@
     <PackageVersion Include="xunit.runner.visualstudio" Version="4.0.0" />
     <PackageVersion Include="coverlet.collector" Version="10.0.1" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="$(EntityFrameworkCoreVersion)" />
+    <PackageVersion Include="SQLitePCLRaw.lib.e_sqlite3" Version="2.1.13" />
   </ItemGroup>
 
   <ItemGroup Label="Provider integration dependencies (net10.0 only)">

--- a/docs/decisions/0008-target-frameworks.md
+++ b/docs/decisions/0008-target-frameworks.md
@@ -37,6 +37,10 @@ EF Core versions are pinned per target framework, so a consumer never gets a mis
 This is implemented with conditional versions in `Directory.Packages.props`, so it is one
 place to change rather than one per project.
 
+Shipping projects compile against the earliest secure patch supported in each line. Tests and samples
+use the current patch. This keeps the NuGet dependency floor low without testing against vulnerable
+packages.
+
 Corollaries:
 
 - CI builds **and tests** both target frameworks, on Ubuntu and Windows. A compile-only pass
@@ -71,6 +75,8 @@ different, worse product wearing the same name.
   runtime installed. `CONTRIBUTING.md` documents running `-f net10.0` locally and letting CI
   cover both.
 - Package validation verifies the shipped framework list is coherent.
+- Package validation installs the net10.0 package beside an older EF Core patch, and checks the
+  dependency floors recorded for both target frameworks.
 
 ## Revisit when
 

--- a/eng/verify-packages.sh
+++ b/eng/verify-packages.sh
@@ -53,6 +53,16 @@ require_entry() {
   fi
 }
 
+require_dependency_version() {
+  local nuspec="$1" dependency="$2" version="$3" description="$4"
+
+  if grep -Fq "<dependency id=\"$dependency\" version=\"$version\"" <<<"$nuspec"; then
+    pass "$description"
+  else
+    fail "$description ($dependency $version not found)"
+  fi
+}
+
 echo "Verifying packages in $PACKAGE_DIR"
 echo
 
@@ -130,6 +140,20 @@ for name in "${EXPECTED_PACKAGES[@]}"; do
     pass "MIT licence expression"
   else
     fail "licence expression missing or not MIT"
+  fi
+
+  if [ "$name" = "QueryGuard.EntityFrameworkCore" ]; then
+    require_dependency_version "$nuspec" "Microsoft.EntityFrameworkCore.Relational" "8.0.1" \
+      "net8.0 EF Core dependency starts at the supported floor"
+    require_dependency_version "$nuspec" "Microsoft.EntityFrameworkCore.Relational" "10.0.0" \
+      "net10.0 EF Core dependency starts at the supported floor"
+  fi
+
+  if [ "$name" = "QueryGuard.AspNetCore.Testing" ]; then
+    require_dependency_version "$nuspec" "Microsoft.AspNetCore.Mvc.Testing" "8.0.1" \
+      "net8.0 ASP.NET Core testing dependency starts at the supported floor"
+    require_dependency_version "$nuspec" "Microsoft.AspNetCore.Mvc.Testing" "10.0.0" \
+      "net10.0 ASP.NET Core testing dependency starts at the supported floor"
   fi
 
   if grep -qE '<description>.{80,}</description>' <<<"$nuspec"; then
@@ -259,7 +283,10 @@ cat >Consumer.csproj <<XML
     <PackageReference Include="QueryGuard.AspNetCore.Testing" Version="$package_version" />
     <PackageReference Include="QueryGuard.Testing" Version="$package_version" />
     <PackageReference Include="QueryGuard.Reporting" Version="$package_version" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.11" />
+    <!-- Keep this below the repository's current EF Core patch. This catches a package that
+         accidentally requires the latest patch instead of the supported 10.0 line. -->
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.10" />
+    <PackageReference Include="SQLitePCLRaw.lib.e_sqlite3" Version="2.1.13" />
   </ItemGroup>
 </Project>
 XML


### PR DESCRIPTION
## What changed

- Shipping packages now use lower dependency floors.
- Tests and samples still use current framework patches.
- Package verification checks the recorded floors and installs beside EF Core 10.0.10.
- The SQLite test dependency uses a patched native library.

## Why

Preview.5 could not restore in a public project pinned to EF Core 10.0.10. QueryGuard did not need the newer patch.

Closes #126

## Tested

- `dotnet format QueryGuard.slnx --verify-no-changes --no-restore`
- Release build for net8.0 and net10.0
- 536 net10.0 tests passed, 1 skipped
- All package checks passed
- The SSW Vertical Slice Architecture SQL Server query-budget test passed with EF Core 10.0.10