### PR TITLE
chore(release): prepare v0.1.0-preview.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ record: breaking changes, privacy-relevant behavior, and report-schema compatibi
 
 ## [Unreleased]
 
+## [0.1.0-preview.6] - 2026-08-21
+
+The main ASP.NET Core testing path is simpler, and packages no longer require the newest framework
+patch installed in this repository.
+
 ### Changed
 
 - Package dependencies now start at the first secure EF Core and ASP.NET Core 8 patch, or at 10.0.0,
@@ -308,7 +313,8 @@ release.
   `Properties/launchSettings.json`, and corrected the query and warning counts quoted in
   `samples/README.md` to what the sample actually logs.
 
-[Unreleased]: https://github.com/Benziza/queryguard-dotnet/compare/v0.1.0-preview.5...main
+[Unreleased]: https://github.com/Benziza/queryguard-dotnet/compare/v0.1.0-preview.6...main
+[0.1.0-preview.6]: https://github.com/Benziza/queryguard-dotnet/compare/v0.1.0-preview.5...v0.1.0-preview.6
 [0.1.0-preview.5]: https://github.com/Benziza/queryguard-dotnet/releases/tag/v0.1.0-preview.5
 [0.1.0-preview.4]: https://github.com/Benziza/queryguard-dotnet/releases/tag/v0.1.0-preview.4
 [0.1.0-preview.3]: https://github.com/Benziza/queryguard-dotnet/releases/tag/v0.1.0-preview.3

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -43,7 +43,7 @@
   <!-- Shared version and identity information. -->
   <PropertyGroup>
     <VersionPrefix>0.1.0</VersionPrefix>
-    <VersionSuffix Condition="'$(VersionSuffix)' == '' AND '$(IsReleaseBuild)' != 'true'">preview.5</VersionSuffix>
+    <VersionSuffix Condition="'$(VersionSuffix)' == '' AND '$(IsReleaseBuild)' != 'true'">preview.6</VersionSuffix>
     <Authors>Mohamed Benziza</Authors>
     <Company>Mohamed Benziza</Company>
     <Product>QueryGuard.NET</Product>


### PR DESCRIPTION
## What changed

- Set the package version to `0.1.0-preview.6`.
- Move the current changelog entries into the new release.

## Why

This preview publishes the simpler ASP.NET Core testing path and the lower framework dependency floors.

## Tested

- `dotnet format QueryGuard.slnx --verify-no-changes`
- `dotnet build QueryGuard.slnx -c Release`
- .NET 10 tests: 536 passed, 1 skipped
- Provider tests: 29 passed
- Package verification and consumer smoke tests passed

GitHub CI runs the full .NET 8 and .NET 10 matrix.