### PR TITLE
docs: publish public validation results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ record: breaking changes, privacy-relevant behavior, and report-schema compatibi
 
 ## [Unreleased]
 
+### Added
+
+- Public validation notes record results from three ASP.NET Core projects and the package dependency
+  problem found during the work.
+
 ## [0.1.0-preview.6] - 2026-08-21
 
 The main ASP.NET Core testing path is simpler, and packages no longer require the newest framework

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ change and exits successfully.
 Publish the Markdown table as a job summary and sticky pull request comment:
 
 ```yaml
-- uses: Benziza/queryguard-dotnet@v0.1.0-preview.5
+- uses: Benziza/queryguard-dotnet@v0.1.0-preview.6
   with:
     summary-path: artifacts/queryguard/summary.md
 ```
@@ -125,6 +125,20 @@ See the [baseline guide](./docs/baselines/README.md) and [action guide](./action
 
 MySQL tests use Oracle's `MySql.EntityFrameworkCore`. Pomelo does not have an EF Core 10 release yet.
 See [provider support](./docs/providers/README.md) for the exact claim and current caveats.
+
+## Tested in public projects
+
+`0.1.0-preview.6` was added to three public ASP.NET Core test suites before the stable release:
+
+| Project | Test stack | Request | Result |
+| --- | --- | --- | --- |
+| [CleanArchitecture](https://github.com/jasontaylordev/CleanArchitecture/tree/10f1a45df0d86bb87b083f3a0e249d755093fbbd) | NUnit, SQLite | `POST /api/Users/register` | 1 query, 1 group |
+| [SSW.VerticalSliceArchitecture](https://github.com/SSWConsulting/SSW.VerticalSliceArchitecture/tree/b3926fe461fa79fd81e163d851f1dec00a5ba84e) | xUnit, SQL Server | `GET /api/heroes` | 2 queries, 2 groups |
+| [CleanArchitecture](https://github.com/alex289/CleanArchitecture/tree/70a13e310abf8742b938a80dff48ae0735f6b5ef) | NUnit, SQL Server | `GET /api/v1/Tenant/{id}` | 2 queries, 2 groups |
+
+All three request tests passed with no repeated-query finding. The
+[validation notes](./docs/case-studies/public-project-validation.md) include the setup, the package
+compatibility problem the work found, and the limits of this check.
 
 ## Scope and privacy
 
@@ -159,6 +173,7 @@ Full documentation and the generated API reference are available at
 | --- | --- |
 | [How it works](./docs/concepts/README.md) | Sessions, fingerprints, redaction, analysis |
 | [Testing](./docs/testing/README.md) | WebApplicationFactory requests and explicit scopes |
+| [Public validation](./docs/case-studies/public-project-validation.md) | Results from three public ASP.NET Core projects |
 | [Configuration](./docs/configuration/README.md) | Budgets and defaults |
 | [Baselines](./docs/baselines/README.md) | Recording and comparing query behavior |
 | [Troubleshooting](./docs/troubleshooting/README.md) | Missing capture, grouping, middleware order |

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,6 +6,8 @@
   and analysis, in the order a command travels through them.
 - [Testing](./testing/README.md): measure `WebApplicationFactory` requests or open an explicit scope
   around a service or background job.
+- [Public project validation](./case-studies/public-project-validation.md): results from three public
+  ASP.NET Core test suites, including the package problem the work found.
 - [Configuration](./configuration/README.md): every budget and option, what it defaults to, and the
   reasoning behind each default.
 - [Baselines](./baselines/README.md): record what a scope costs today and report what changed, so

--- a/docs/case-studies/public-project-validation.md
+++ b/docs/case-studies/public-project-validation.md
@@ -1,0 +1,56 @@
+# Public project validation
+
+QueryGuard `0.1.0-preview.6` was tested in three public ASP.NET Core projects before the stable
+`0.1.0` release.
+
+This is a compatibility check, not an adoption claim. The test changes stayed in local checkouts. No
+pull requests were opened in the other projects because their maintainers did not request these
+changes.
+
+## Method
+
+For each project, the validation used an existing integration test setup:
+
+1. Check out the exact commit listed below.
+2. Install `QueryGuard.AspNetCore.Testing` from nuget.org.
+3. Add one `WebApplicationFactory` request test with `TrackQueries`.
+4. Set a total query budget and allow only one occurrence per fingerprint.
+5. Assert the exact query count and record the result.
+
+The final run used the published `0.1.0-preview.6` packages, not a local package feed.
+
+## Results
+
+| Project and commit | Framework and provider | Request | QueryGuard result |
+| --- | --- | --- | --- |
+| [jasontaylordev/CleanArchitecture at `10f1a45`](https://github.com/jasontaylordev/CleanArchitecture/tree/10f1a45df0d86bb87b083f3a0e249d755093fbbd) | NUnit, SQLite | `POST /api/Users/register` | 1 read query, 1 group, 0 findings |
+| [SSWConsulting/SSW.VerticalSliceArchitecture at `b3926fe`](https://github.com/SSWConsulting/SSW.VerticalSliceArchitecture/tree/b3926fe461fa79fd81e163d851f1dec00a5ba84e) | xUnit, SQL Server Testcontainers | `GET /api/heroes` | 2 read queries, 2 groups, 0 findings |
+| [alex289/CleanArchitecture at `70a13e3`](https://github.com/alex289/CleanArchitecture/tree/70a13e310abf8742b938a80dff48ae0735f6b5ef) | NUnit, SQL Server Testcontainers | `GET /api/v1/Tenant/{id}` | 2 read queries, 2 groups, 0 findings |
+
+The request setup worked with both NUnit and xUnit, and with SQLite and SQL Server. No QueryGuard
+false positive appeared in these three requests.
+
+## What the work found
+
+The first SSW restore failed before the test could run. `0.1.0-preview.5` required EF Core `10.0.11`,
+while the project pinned `10.0.10`. QueryGuard did not need that exact patch. [Issue #126](https://github.com/Benziza/queryguard-dotnet/issues/126)
+tracked the problem, and [pull request #127](https://github.com/Benziza/queryguard-dotnet/pull/127)
+lowered the package dependency floors. The same project restored and passed with `0.1.0-preview.6`.
+
+The alex289 request first used a total budget of one and failed with two different queries. The
+endpoint reads the tenant and its users separately. Raising the total budget to two while keeping the
+per-fingerprint limit at one represented the endpoint correctly and still guarded against repetition.
+
+The Jason Taylor checkout requested .NET SDK `10.0.400`, which was not installed on the validation
+machine. The checkout used the installed `10.0.302` feature band for this test. No QueryGuard change
+was needed.
+
+## Limits
+
+- Only one request was tested in each project.
+- This does not measure performance or long-running application behavior.
+- Existing warnings from the projects were outside QueryGuard and were not treated as product results.
+- These local validation patches are not support commitments from the other maintainers.
+
+The validation found one packaging problem, verified its fix from nuget.org, and found no blocker for
+the stable `0.1.0` API.

--- a/docs/toc.yml
+++ b/docs/toc.yml
@@ -6,6 +6,8 @@
       href: concepts/README.md
     - name: Testing
       href: testing/README.md
+    - name: Public validation
+      href: case-studies/public-project-validation.md
     - name: Configuration
       href: configuration/README.md
     - name: Baselines


### PR DESCRIPTION
## What changed

- Add results from three public ASP.NET Core projects.
- Record the package compatibility problem found during validation.
- Link the results from the README and documentation site.
- Update the action example to `v0.1.0-preview.6`.

## Why

Stable `0.1.0` should be based on tests outside this repository.

## Tested

- All three request tests passed with packages restored from nuget.org.
- `dotnet docfx docs/docfx.json --warningsAsErrors`
- No em dash punctuation in the repository.