### PR TITLE
chore(release): prepare v0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ record: breaking changes, privacy-relevant behavior, and report-schema compatibi
 
 ## [Unreleased]
 
+## [0.1.0] - 2026-08-21
+
+First stable release. The package API is stable within the `0.1` release line.
+
 ### Added
 
 - Public validation notes record results from three ASP.NET Core projects and the package dependency
@@ -318,7 +322,8 @@ release.
   `Properties/launchSettings.json`, and corrected the query and warning counts quoted in
   `samples/README.md` to what the sample actually logs.
 
-[Unreleased]: https://github.com/Benziza/queryguard-dotnet/compare/v0.1.0-preview.6...main
+[Unreleased]: https://github.com/Benziza/queryguard-dotnet/compare/v0.1.0...main
+[0.1.0]: https://github.com/Benziza/queryguard-dotnet/compare/v0.1.0-preview.6...v0.1.0
 [0.1.0-preview.6]: https://github.com/Benziza/queryguard-dotnet/compare/v0.1.0-preview.5...v0.1.0-preview.6
 [0.1.0-preview.5]: https://github.com/Benziza/queryguard-dotnet/releases/tag/v0.1.0-preview.5
 [0.1.0-preview.4]: https://github.com/Benziza/queryguard-dotnet/releases/tag/v0.1.0-preview.4

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -43,7 +43,6 @@
   <!-- Shared version and identity information. -->
   <PropertyGroup>
     <VersionPrefix>0.1.0</VersionPrefix>
-    <VersionSuffix Condition="'$(VersionSuffix)' == '' AND '$(IsReleaseBuild)' != 'true'">preview.6</VersionSuffix>
     <Authors>Mohamed Benziza</Authors>
     <Company>Mohamed Benziza</Company>
     <Product>QueryGuard.NET</Product>

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ visible with a written reason.
 For an ASP.NET Core integration test, install the WebApplicationFactory helper:
 
 ```bash
-dotnet add package QueryGuard.AspNetCore.Testing --prerelease
+dotnet add package QueryGuard.AspNetCore.Testing
 ```
 
 Open a measurement, run the request, and assert the result:
@@ -95,7 +95,7 @@ on request paths because they are much more expensive than normal capture.
 If you do not know the right budget yet, record current behavior and compare it in CI:
 
 ```bash
-dotnet tool install -g QueryGuard.Cli --prerelease
+dotnet tool install -g QueryGuard.Cli
 
 queryguard baseline record
 queryguard verify --summary artifacts/queryguard/summary.md
@@ -107,7 +107,7 @@ change and exits successfully.
 Publish the Markdown table as a job summary and sticky pull request comment:
 
 ```yaml
-- uses: Benziza/queryguard-dotnet@v0.1.0-preview.6
+- uses: Benziza/queryguard-dotnet@v0.1.0
   with:
     summary-path: artifacts/queryguard/summary.md
 ```
@@ -148,7 +148,7 @@ QueryGuard is focused on query-count regressions.
 - It does not observe Dapper or raw ADO.NET.
 - It does not collect execution plans or provide a profiler UI.
 - It does not rewrite queries or change HTTP responses.
-- It is still in preview, so public APIs may change before `1.0.0`.
+- The `0.1` public API is stable within the `0.1` release line. The project has not reached `1.0.0`.
 
 Parameter values and connection strings are not captured. Redaction runs before any reporter receives
 SQL. The JSON report has a `schemaVersion` so format changes are explicit.

--- a/action/README.md
+++ b/action/README.md
@@ -4,12 +4,12 @@ Publishes a QueryGuard query-count report to the job summary and, on a pull requ
 comment**: one comment that gets edited rather than a new one per push.
 
 ```yaml
-- uses: Benziza/queryguard-dotnet@v0.1.0-preview.5
+- uses: Benziza/queryguard-dotnet@v0.1.0
 ```
 
 That is the whole thing.
 
-The root form starts with `v0.1.0-preview.5`. Older releases keep the compatible
+The root form starts with `v0.1.0`. Older releases keep the compatible
 `Benziza/queryguard-dotnet/action@<tag>` path.
 
 ## What it looks like
@@ -45,10 +45,10 @@ jobs:
 
       - run: dotnet test
 
-      - run: dotnet tool install -g QueryGuard.Cli --prerelease
+      - run: dotnet tool install -g QueryGuard.Cli
       - run: queryguard verify --summary artifacts/queryguard/summary.md
 
-      - uses: Benziza/queryguard-dotnet@v0.1.0-preview.5
+      - uses: Benziza/queryguard-dotnet@v0.1.0
         with:
           summary-path: artifacts/queryguard/summary.md
 ```

--- a/docs/baselines/README.md
+++ b/docs/baselines/README.md
@@ -77,7 +77,7 @@ a failure.
 The library can do all of this from a test. The command-line tool does the file handling for you:
 
 ```bash
-dotnet tool install -g QueryGuard.Cli --prerelease
+dotnet tool install -g QueryGuard.Cli
 ```
 
 Have the test run write JSON reports:

--- a/docs/index.md
+++ b/docs/index.md
@@ -20,7 +20,7 @@ into something a test can fail on.
 ## Install
 
 ```bash
-dotnet add package QueryGuard.AspNetCore.Testing --prerelease
+dotnet add package QueryGuard.AspNetCore.Testing
 ```
 
 This package measures real `WebApplicationFactory` requests and works with any test framework.
@@ -76,14 +76,14 @@ running seven more of them, which a total-count budget cannot see.
 In CI, without writing plumbing:
 
 ```bash
-dotnet tool install -g QueryGuard.Cli --prerelease
+dotnet tool install -g QueryGuard.Cli
 
 queryguard baseline record          # once, then commit the file
 queryguard verify --summary artifacts/queryguard/summary.md
 ```
 
 ```yaml
-- uses: Benziza/queryguard-dotnet@v0.1.0-preview.5
+- uses: Benziza/queryguard-dotnet@v0.1.0
 ```
 
 The action posts that table as a sticky pull request comment. See [baselines](baselines/README.md).

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -4,7 +4,7 @@ This roadmap describes direction, not a schedule. Real usage and false-positive 
 moves next. Open an [issue or discussion](https://github.com/Benziza/queryguard-dotnet/issues/new/choose)
 to add evidence.
 
-## v0.1 preview
+## v0.1
 
 The goal is simple: install QueryGuard, run the sample, and get one actionable repeated-query finding
 in under three minutes.
@@ -61,9 +61,9 @@ next plausible integration because it sends results to tools teams already use.
 
 ### Adoption evidence
 
-Validate QueryGuard in public applications before declaring the API stable. The current target is
-three public projects with setup notes, false positives, and real feedback. Track it in
-[issue #117](https://github.com/Benziza/queryguard-dotnet/issues/117).
+The stable API was checked in three public projects. That work found and fixed one package dependency
+problem. The [validation notes](./case-studies/public-project-validation.md) record the results and
+limits, and [issue #117](https://github.com/Benziza/queryguard-dotnet/issues/117) is complete.
 
 ## How priority is decided
 
@@ -80,7 +80,7 @@ going quiet.
 
 The project should keep expanding when real use produces strong signals such as:
 
-- three public projects using it
+- successful compatibility checks in public projects
 - repeat users across releases
 - false-positive or provider feedback from real applications
 

--- a/docs/testing/README.md
+++ b/docs/testing/README.md
@@ -8,7 +8,7 @@ produce the same `QueryGuardResult` and use the same assertions.
 Install the helper package:
 
 ```bash
-dotnet add package QueryGuard.AspNetCore.Testing --prerelease
+dotnet add package QueryGuard.AspNetCore.Testing
 ```
 
 Measure a request made through `WebApplicationFactory`:
@@ -50,7 +50,7 @@ measure. Open separate measurements when a test needs separate budgets for separ
 Install the general testing package:
 
 ```bash
-dotnet add package QueryGuard.Testing --prerelease
+dotnet add package QueryGuard.Testing
 ```
 
 Attach QueryGuard when the context is configured:

--- a/src/QueryGuard.Cli/PACKAGE.md
+++ b/src/QueryGuard.Cli/PACKAGE.md
@@ -5,7 +5,7 @@ reports, and verifies later runs against it, so a query-count regression shows u
 baseline plumbing written by hand.
 
 ```bash
-dotnet tool install -g QueryGuard.Cli --prerelease
+dotnet tool install -g QueryGuard.Cli
 ```
 
 ## The workflow
@@ -83,14 +83,14 @@ a sticky pull request comment:
 ```yaml
 - run: dotnet test
 - run: queryguard verify --summary artifacts/queryguard/summary.md
-- uses: Benziza/queryguard-dotnet@v0.1.0-preview.5
+- uses: Benziza/queryguard-dotnet@v0.1.0
 ```
 
 Full documentation:
 [docs/baselines](https://benziza.github.io/queryguard-dotnet/baselines/README.html).
 
-## Preview
+## Versioning
 
-Public APIs and the baseline schema may change before `1.0.0`. The baseline document carries its own
-`schemaVersion`, and a file written by a future major version is rejected rather than read optimistically
-a silently empty baseline would report every scope as new and hide every regression in the run.
+The `0.1` public API is stable within the `0.1` release line. The baseline document carries its own
+`schemaVersion`, and a file written by a future major version is rejected rather than read
+optimistically. A silently empty baseline would report every scope as new and hide every regression.


### PR DESCRIPTION
## What changed

- Set the package version to stable `0.1.0`.
- Add the stable changelog entry.
- Remove `--prerelease` from install commands.
- Pin action examples to `v0.1.0`.
- Mark the public `0.1` API as stable within the `0.1` line.

## Why

The published preview passed the release workflow and validation in three public projects.

## Tested

- `dotnet format QueryGuard.slnx --verify-no-changes`
- `dotnet build QueryGuard.slnx -c Release`
- `dotnet docfx docs/docfx.json --warningsAsErrors`
- Package verification and consumer smoke tests passed for `0.1.0`

The release dry run and pull request checks provide the final full test matrix.