### PR TITLE
fix: redact PostgreSQL and escaped SQL string literals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,16 @@ record: breaking changes, privacy-relevant behavior, and report-schema compatibi
 
 ## [Unreleased]
 
+### Fixed
+
+- Redact PostgreSQL dollar-quoted strings and escaped quotes in `E'...'` strings before SQL reaches
+  reports. Normalization preserves these literal boundaries, including comments inside strings.
+- For a backslash-escaped quote in an ordinary string, redact the remaining SQL conservatively:
+  its closing quote depends on the database's SQL mode, which QueryGuard does not know. This can
+  shorten SQL evidence and group more queries together. Fingerprints for affected SQL change;
+  review related baselines and fingerprint allowlists after upgrading. Public APIs and report
+  schemas are unchanged.
+
 ## [0.1.0] - 2026-08-21
 
 First stable release. The package API is stable within the `0.1` release line.

--- a/docs/configuration/README.md
+++ b/docs/configuration/README.md
@@ -172,6 +172,17 @@ This is on in a scope and **off** on a request path, because it costs 20–30× 
 path: free in a test, not free in production. See
 [ADR-0007](../decisions/0007-stack-trace-policy.md) and [benchmarks](../benchmarks.md).
 
+## SQL string privacy
+
+String redaction covers single-quoted strings, PostgreSQL `E'...'` escape strings, and
+`$$...$$` or `$tag$...$tag$` strings. Quotes and comment markers inside these strings stay
+inside the literal during normalization, so their contents are removed before reporting.
+
+An ordinary string containing a backslash before a quote is ambiguous without the database's
+SQL mode. QueryGuard hides the remainder of that command in this case. This can shorten the
+reported SQL and group more queries together. Use parameterized SQL to avoid this ambiguity.
+Setting `RedactStringLiterals = false` explicitly keeps string contents.
+
 ## In tests
 
 ```csharp

--- a/src/QueryGuard.Core/QueryGuardRedactor.cs
+++ b/src/QueryGuard.Core/QueryGuardRedactor.cs
@@ -200,7 +200,9 @@ public sealed class QueryGuardRedactor : IQueryGuardRedactor
     /// Single-pass and intentionally conservative. Quoted identifiers: <c>"Departments"</c> in
     /// SQLite and PostgreSQL, <c>[Departments]</c> in SQL Server, and <c>`Departments`</c> in MySQL, are
     /// left alone, because a table name is structure rather than data and removing it would make the
-    /// evidence unreadable. Doubled quotes inside a string literal are handled as escapes.
+    /// evidence unreadable. Literal boundaries are shared with the normalizer, including PostgreSQL
+    /// dollar quotes and escape strings. Ambiguous ordinary backslash quotes consume the remainder
+    /// conservatively because the database's SQL mode is not available here.
     /// </remarks>
     private string RedactLiterals(string sql)
     {
@@ -215,6 +217,11 @@ public sealed class QueryGuardRedactor : IQueryGuardRedactor
             {
                 case '\'':
                     index = AppendStringLiteral(sql, index, builder);
+                    continue;
+
+                case '$' when SqlStringLiteralScanner.TryDollarQuotedEnd(sql, index, out var literalEnd):
+                    AppendLiteral(sql, index, literalEnd, builder);
+                    index = literalEnd;
                     continue;
 
                 case '-' when index + 1 < sql.Length && sql[index + 1] == '-':
@@ -259,37 +266,21 @@ public sealed class QueryGuardRedactor : IQueryGuardRedactor
 
     private int AppendStringLiteral(string sql, int index, StringBuilder builder)
     {
-        var start = index;
-        index++; // opening quote
+        var end = SqlStringLiteralScanner.SingleQuotedEnd(sql, index);
+        AppendLiteral(sql, index, end, builder);
+        return end;
+    }
 
-        while (index < sql.Length)
-        {
-            if (sql[index] == '\'')
-            {
-                // A doubled quote is an escaped quote inside the literal, not the end of it.
-                if (index + 1 < sql.Length && sql[index + 1] == '\'')
-                {
-                    index += 2;
-                    continue;
-                }
-
-                index++;
-                break;
-            }
-
-            index++;
-        }
-
+    private void AppendLiteral(string sql, int start, int end, StringBuilder builder)
+    {
         if (_options.RedactStringLiterals)
         {
             builder.Append('\'').Append(LiteralPlaceholderChar).Append('\'');
         }
         else
         {
-            builder.Append(sql, start, index - start);
+            builder.Append(sql, start, end - start);
         }
-
-        return index;
     }
 
     private static int AppendQuotedIdentifier(string sql, int index, StringBuilder builder, char closingChar)

--- a/src/QueryGuard.Core/SqlNormalizer.cs
+++ b/src/QueryGuard.Core/SqlNormalizer.cs
@@ -68,6 +68,11 @@ public sealed class SqlNormalizer : ISqlNormalizer
                     index = CopyStringLiteral(commandText, index, builder);
                     continue;
 
+                case '$' when SqlStringLiteralScanner.TryDollarQuotedEnd(commandText, index, out var literalEnd):
+                    builder.Append(commandText, index, literalEnd - index);
+                    index = literalEnd;
+                    continue;
+
                 case '"':
                     index = CopyDelimited(commandText, index, builder, '"');
                     continue;
@@ -153,25 +158,7 @@ public sealed class SqlNormalizer : ISqlNormalizer
     private static int CopyStringLiteral(string text, int index, StringBuilder builder)
     {
         var start = index;
-        index++;
-
-        while (index < text.Length)
-        {
-            if (text[index] == '\'')
-            {
-                // A doubled quote is an escaped quote inside the literal, not its end.
-                if (Peek(text, index + 1) == '\'')
-                {
-                    index += 2;
-                    continue;
-                }
-
-                index++;
-                break;
-            }
-
-            index++;
-        }
+        index = SqlStringLiteralScanner.SingleQuotedEnd(text, index);
 
         builder.Append(text, start, index - start);
         return index;

--- a/src/QueryGuard.Core/SqlStringLiteralScanner.cs
+++ b/src/QueryGuard.Core/SqlStringLiteralScanner.cs
@@ -1,0 +1,98 @@
+using System;
+
+namespace QueryGuard;
+
+/// <summary>
+/// Finds literal boundaries shared by normalization and redaction.
+/// </summary>
+internal static class SqlStringLiteralScanner
+{
+    internal static int SingleQuotedEnd(string text, int openingQuote)
+    {
+        var escapeString = openingQuote > 0
+            && text[openingQuote - 1] is 'E' or 'e'
+            && (openingQuote == 1 || !IsIdentifierPart(text[openingQuote - 2]));
+        var index = openingQuote + 1;
+
+        while (index < text.Length)
+        {
+            if (text[index] == '\\' && index + 1 < text.Length)
+            {
+                if (!escapeString && text[index + 1] == '\'')
+                {
+                    // Without a provider or SQL mode, this quote may close a standard SQL string
+                    // or be escaped in MySQL. Retain neither interpretation's possible values:
+                    // treat the rest as literal content, including any later strings.
+                    return text.Length;
+                }
+
+                // E'...' has explicit PostgreSQL escape semantics. For ordinary strings, pairs
+                // of backslashes do not change where a quote closes in either interpretation.
+                if (escapeString || text[index + 1] == '\\')
+                {
+                    index += 2;
+                    continue;
+                }
+            }
+
+            if (text[index] == '\'')
+            {
+                if (index + 1 < text.Length && text[index + 1] == '\'')
+                {
+                    index += 2;
+                    continue;
+                }
+
+                return index + 1;
+            }
+
+            index++;
+        }
+
+        return text.Length;
+    }
+
+    internal static bool TryDollarQuotedEnd(string text, int start, out int end)
+    {
+        end = start;
+        if (start > 0 && IsIdentifierPart(text[start - 1]))
+        {
+            return false;
+        }
+
+        var position = start + 1;
+        if (position < text.Length && text[position] != '$')
+        {
+            if (!IsTagStart(text[position]))
+            {
+                return false;
+            }
+
+            position++;
+            while (position < text.Length && (IsTagStart(text[position]) || char.IsDigit(text[position])))
+            {
+                position++;
+            }
+        }
+
+        if (position >= text.Length || text[position] != '$')
+        {
+            return false;
+        }
+
+        var delimiterLength = position - start + 1;
+        var contentStart = position + 1;
+        var delimiter = text.AsSpan(start, delimiterLength);
+        var closingOffset = text.AsSpan(contentStart).IndexOf(delimiter, StringComparison.Ordinal);
+
+        // An unterminated literal can arrive on the command-failure path. Its remaining content
+        // is still private. Only the exact, case-sensitive opening delimiter can close it.
+        end = closingOffset < 0 ? text.Length : contentStart + closingOffset + delimiterLength;
+        return true;
+    }
+
+    // PostgreSQL accepts high-bit characters in unquoted identifiers and dollar-quote tags.
+    private static bool IsTagStart(char value) => char.IsAsciiLetter(value) || value == '_' || value >= '\u0080';
+
+    private static bool IsIdentifierPart(char value) => IsTagStart(value) || char.IsAsciiDigit(value) || value == '$';
+}

--- a/tests/QueryGuard.Core.Tests/ProviderStringLiteralTests.cs
+++ b/tests/QueryGuard.Core.Tests/ProviderStringLiteralTests.cs
@@ -1,0 +1,94 @@
+using System;
+using Xunit;
+
+namespace QueryGuard.Tests;
+
+public class ProviderStringLiteralTests
+{
+    [Theory]
+    [InlineData("$$private_value$$")]
+    [InlineData("$tag$private_value$tag$")]
+    [InlineData("$_tag9$private_value$_tag9$")]
+    [InlineData("$étiquette$private_value$étiquette$")]
+    [InlineData("$ta\u0301g$private_value$ta\u0301g$")]
+    [InlineData("$tag$private_value $other$ ' @p0 -- comment\n /* text */ $tag$")]
+    [InlineData("$$private_value")]
+    [InlineData("$tag$private_value$TAG$")]
+    [InlineData("E'prefix\\'private_value'")]
+    [InlineData("e'prefix\\'private_value -- @p0 /* text */'")]
+    [InlineData("E'prefix\\'private_value")]
+    [InlineData("E'prefix\\\\\\'private_value'")]
+    [InlineData("'prefix\\'private_value'")]
+    [InlineData("'\\', 'private_value'")]
+    public void Provider_strings_do_not_retain_values(string literal)
+    {
+        var sql = "SELECT " + literal;
+        var redactor = new QueryGuardRedactor();
+        var redacted = redactor.RedactSql(sql);
+        var fingerprint = new QueryFingerprintFactory().Create(sql, QueryCommandKind.Reader);
+
+        Assert.DoesNotContain("private_value", redacted, StringComparison.Ordinal);
+        Assert.DoesNotContain("private_value", fingerprint.NormalizedSql, StringComparison.Ordinal);
+        Assert.Equal(redacted, redactor.RedactSql(redacted));
+    }
+
+    [Theory]
+    [InlineData("$$private_value @p0 -- text\n /* text */ ';'$$")]
+    [InlineData("$tag$private_value $other$ @p0$tag$")]
+    [InlineData("E'prefix\\'private_value -- @p0 /* text */'")]
+    [InlineData("E'prefix\\\\'", "SELECT E'?' FROM \"T\" WHERE \"Id\" = ?")]
+    [InlineData("'prefix\\\\'", "SELECT '?' FROM \"T\" WHERE \"Id\" = ?")]
+    public void Normalization_preserves_literal_boundaries_and_following_sql(
+        string literal, string? expected = null)
+    {
+        var sql = $"SELECT {literal} FROM \"T\" WHERE \"Id\" = @p0;";
+        var normalized = new SqlNormalizer().Normalize(sql);
+
+        Assert.Equal($"SELECT {literal} FROM \"T\" WHERE \"Id\" = ?", normalized);
+        var fingerprint = new QueryFingerprintFactory().Create(sql, QueryCommandKind.Reader);
+        Assert.Equal(expected ?? (literal.StartsWith('E') ? "SELECT E'?'" : "SELECT '?'")
+            + " FROM \"T\" WHERE \"Id\" = ?", fingerprint.NormalizedSql);
+    }
+
+    [Theory]
+    [InlineData("$$private_value 123$$")]
+    [InlineData("$tag$private_value 123$tag$")]
+    [InlineData("E'prefix\\'private_value 123'")]
+    public void Disabling_string_redaction_preserves_whole_literals(string literal)
+    {
+        var redactor = new QueryGuardRedactor(new QueryGuardCaptureOptions { RedactStringLiterals = false });
+
+        Assert.Equal($"SELECT {literal}, ?", redactor.RedactSql($"SELECT {literal}, 42"));
+    }
+
+    [Theory]
+    [InlineData("$$first$$", "$tag$second$tag$")]
+    [InlineData("E'first\\'value'", "E'second\\'value'")]
+    public void Changing_only_literal_values_keeps_the_fingerprint(string first, string second)
+    {
+        var factory = new QueryFingerprintFactory();
+
+        Assert.Equal(factory.Create("SELECT " + first, QueryCommandKind.Reader).Id,
+            factory.Create("SELECT " + second, QueryCommandKind.Reader).Id);
+    }
+
+    [Fact]
+    public void Dollar_parameters_and_identifiers_keep_their_meaning()
+    {
+        var factory = new QueryFingerprintFactory();
+        var fingerprint = factory.Create("SELECT column$tag$, $1, $23 FROM \"$tag$table\"", QueryCommandKind.Reader);
+
+        Assert.Equal("SELECT column$tag$, ?, ? FROM \"$tag$table\"", fingerprint.NormalizedSql);
+    }
+
+    [Fact]
+    public void An_ambiguous_backslash_quote_hides_both_sql_mode_interpretations()
+    {
+        var factory = new QueryFingerprintFactory();
+
+        Assert.Equal("SELECT '?'", factory.Create(
+            "SELECT '\\', 'private_value' FROM \"T\"", QueryCommandKind.Reader).NormalizedSql);
+        Assert.Equal("SELECT '?'", factory.Create(
+            "SELECT 'prefix\\'private_value' FROM \"T\"", QueryCommandKind.Reader).NormalizedSql);
+    }
+}

--- a/tests/QueryGuard.ProviderTests/PostgreSqlProviderTests.cs
+++ b/tests/QueryGuard.ProviderTests/PostgreSqlProviderTests.cs
@@ -147,6 +147,33 @@ public sealed class PostgreSqlProviderTests : IAsyncLifetime
     }
 
     [DockerFact]
+    public async Task Dollar_quoted_and_escape_strings_are_redacted_after_real_execution()
+    {
+        await using var context = CreateContext();
+        var session = NewSession();
+        string[] statements =
+        [
+            "SELECT $$private_value$$ AS \"Value\"",
+            "SELECT $tag$private_value @p0 -- comment\n /* text */$tag$ AS \"Value\"",
+            "SELECT E'prefix\\'private_value' AS \"Value\"",
+        ];
+
+        using (_accessor.Activate(session))
+        {
+            foreach (var sql in statements)
+            {
+                var values = await context.Database.SqlQueryRaw<string>(sql).ToListAsync();
+                Assert.Contains("private_value", Assert.Single(values), StringComparison.Ordinal);
+            }
+        }
+
+        var records = session.Complete().Records;
+        Assert.Equal(statements.Length, records.Count);
+        Assert.All(records, record =>
+            Assert.DoesNotContain("private_value", record.Fingerprint.NormalizedSql, StringComparison.Ordinal));
+    }
+
+    [DockerFact]
     public async Task A_failing_command_is_recorded_and_the_npgsql_exception_still_surfaces()
     {
         await using var context = CreateContext();

--- a/tests/QueryGuard.Reporting.Tests/ProviderStringPrivacyTests.cs
+++ b/tests/QueryGuard.Reporting.Tests/ProviderStringPrivacyTests.cs
@@ -1,0 +1,33 @@
+using System;
+using Xunit;
+
+namespace QueryGuard.Reporting.Tests;
+
+public class ProviderStringPrivacyTests
+{
+    [Theory]
+    [InlineData("SELECT $$private_value$$")]
+    [InlineData("SELECT $tag$private_value @p0 -- comment\n /* text */$tag$")]
+    [InlineData("SELECT E'prefix\\'private_value'")]
+    [InlineData("SELECT 'prefix\\'private_value'")]
+    public void Captured_literals_do_not_reach_any_sql_report(string sql)
+    {
+        var session = new QueryGuardSession("privacy", QueryGuardPolicy.Create("privacy").WithMaxQueries(0));
+        var fingerprint = new QueryFingerprintFactory().Create(sql, QueryCommandKind.Reader);
+        session.Record(QueryCommandKind.Reader, fingerprint, TimeSpan.Zero);
+        var result = new QueryGuardAnalyzer().Analyze(session.Complete());
+        Assert.False(result.IsSuccess);
+        QueryGuardReporter[] reporters =
+        [
+            new QueryGuardJsonReporter(),
+            new QueryGuardConsoleReporter(),
+            new QueryGuardJUnitReporter(),
+            new QueryGuardSarifReporter(),
+        ];
+
+        foreach (var reporter in reporters)
+        {
+            Assert.DoesNotContain("private_value", reporter.Render(result), StringComparison.Ordinal);
+        }
+    }
+}


### PR DESCRIPTION
## What changed

Fix SQL string values remaining visible in fingerprints and reports. Normalization and redaction now share literal boundaries for PostgreSQL dollar quotes and `E'...'` escape strings, including unterminated strings and comment markers inside values.

For ordinary strings with an ambiguous backslash-quote, hide the remainder of the command because its closing quote depends on the database's SQL mode. Document this tradeoff and the changed fingerprints in the configuration guide and changelog. Public APIs and report schemas stay unchanged.

## Why

The default privacy settings must remove inline string values before reporters receive SQL. For example, `SELECT $$private_value$$` previously retained the value; it now becomes `SELECT '?'`. Tests use synthetic data only.

## How it was tested

- New core regression tests reproduced 18 failures before the fix.
- `dotnet build QueryGuard.slnx -c Release --no-restore` passed for .NET 8 and 10, with no warnings.
- `dotnet test QueryGuard.slnx -c Release -f net10.0 --no-build --no-restore`: 542 passed, 26 skipped (25 Docker tests and one sample maintenance helper).
- `dotnet format QueryGuard.slnx --verify-no-changes --no-restore` and `git diff --check` passed.
- All 9 fingerprint benchmark cases completed with `--job Dry`; this is a smoke check, not a performance measurement.
- Coverage includes literal boundaries, escape parity, redaction opt-out, idempotence, stable fingerprints, and JSON/console/JUnit/SARIF output. Added a real PostgreSQL execution test for CI.

Docker is unavailable locally, and the .NET 8 runtime is not installed; live PostgreSQL execution and .NET 8 test execution remain for CI.