### PR TITLE
fix: count reads correctly when SQL text contains write keywords

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ record: breaking changes, privacy-relevant behavior, and report-schema compatibi
 
 ### Fixed
 
+- Count reads correctly when strings, quoted identifiers, or comments contain semicolons followed
+  by write keywords. Recognize writes after leading comments and require complete keyword tokens.
+  This corrects read budgets on successful and failed EF Core commands without changing executed SQL.
+
 - Redact PostgreSQL dollar-quoted strings and escaped quotes in `E'...'` strings before SQL reaches
   reports. Normalization preserves these literal boundaries, including comments inside strings.
 - For a backslash-escaped quote in an ordinary string, redact the remaining SQL conservatively:

--- a/docs/configuration/README.md
+++ b/docs/configuration/README.md
@@ -89,6 +89,15 @@ Note that "what a command does" is not the same as "which EF Core method execute
 runs `INSERT … RETURNING` through the reader path to read the generated key back: QueryGuard classifies
 that as a write anyway, or a budget of ten reads would mean something different on every provider.
 
+Only a complete write keyword at the start of a statement marks a reader command as a write.
+Strings, quoted identifiers, and comments are skipped when finding statement boundaries. For example,
+`SELECT ';DELETE'` counts as one read, while `/* tag */ INSERT ... RETURNING ...` counts as a write.
+SQL Server batches with `SET` statements before a write keep the same behavior.
+
+This is a lexical check, not a full SQL parser. CTEs and stored procedure bodies are not interpreted.
+If no clear write statement is found, QueryGuard keeps the execution kind supplied by EF Core;
+failed commands with no execution kind keep the existing read fallback.
+
 ## Capture and privacy
 
 ```csharp

--- a/src/QueryGuard.Core/QueryGuard.Core.csproj
+++ b/src/QueryGuard.Core/QueryGuard.Core.csproj
@@ -13,6 +13,7 @@
   <ItemGroup>
     <InternalsVisibleTo Include="QueryGuard.Reporting" />
     <InternalsVisibleTo Include="QueryGuard.Testing" />
+    <InternalsVisibleTo Include="QueryGuard.EntityFrameworkCore" />
   </ItemGroup>
 
 </Project>

--- a/src/QueryGuard.EntityFrameworkCore/QueryGuardCommandInterceptor.cs
+++ b/src/QueryGuard.EntityFrameworkCore/QueryGuardCommandInterceptor.cs
@@ -220,8 +220,9 @@ public sealed class QueryGuardCommandInterceptor : DbCommandInterceptor
     /// </para>
     /// <para>
     /// So a command executed as a reader is demoted to <see cref="QueryCommandKind.NonQuery"/> when
-    /// its statement clearly modifies data. The leading keyword is the only signal needed for that.
-    /// This is not, and must not become, SQL parsing.
+    /// a statement clearly modifies data. Classification skips strings, quoted identifiers, and
+    /// comments before checking complete leading keywords in each statement. This is a lexical
+    /// check, not a SQL parser: CTEs and stored procedure bodies are not interpreted.
     /// </para>
     /// </remarks>
     private static QueryCommandKind Classify(QueryCommandKind executionKind, string? commandText)
@@ -231,7 +232,7 @@ public sealed class QueryGuardCommandInterceptor : DbCommandInterceptor
             return executionKind;
         }
 
-        var isModification = IsModificationStatement(commandText);
+        var isModification = SqlCommandClassifier.ContainsModification(commandText);
 
         return executionKind switch
         {
@@ -244,65 +245,4 @@ public sealed class QueryGuardCommandInterceptor : DbCommandInterceptor
             _ => executionKind,
         };
     }
-
-    /// <summary>
-    /// Reports whether any statement in the batch modifies data.
-    /// </summary>
-    /// <remarks>
-    /// <para>
-    /// Every statement, not just the first one, because a provider is free to put something else in
-    /// front of the interesting part. EF Core's SQL Server insert batch does exactly that:
-    /// </para>
-    /// <code>
-    /// SET IMPLICIT_TRANSACTIONS OFF;
-    /// SET NOCOUNT ON;
-    /// INSERT INTO [Departments] ([Id], [CompanyId], [Name]) VALUES (@p0, @p1, @p2);
-    /// </code>
-    /// <para>
-    /// Checking only the leading keyword saw <c>SET</c>, left the command classified as a read, and
-    /// so counted every <c>SaveChanges</c> on SQL Server against read budgets. A live suite caught
-    /// that; the captured fixtures could not, because they only ever contained the SQL someone
-    /// thought to capture.
-    /// </para>
-    /// <para>
-    /// This walks statements separated by <c>;</c> and tests each leading keyword. It is deliberately
-    /// not SQL parsing: no quote tracking, no nesting, no comment handling. A read batch that
-    /// genuinely contains a modification statement is a write as far as a read budget is concerned,
-    /// which is the answer this needs to give anyway.
-    /// </para>
-    /// </remarks>
-    private static bool IsModificationStatement(string commandText)
-    {
-        var remaining = commandText.AsSpan();
-
-        while (!remaining.IsEmpty)
-        {
-            var end = remaining.IndexOf(';');
-            var statement = (end < 0 ? remaining : remaining[..end]).TrimStart();
-
-            if (StartsWithModificationKeyword(statement))
-            {
-                return true;
-            }
-
-            if (end < 0)
-            {
-                return false;
-            }
-
-            remaining = remaining[(end + 1)..];
-        }
-
-        return false;
-    }
-
-    private static bool StartsWithModificationKeyword(ReadOnlySpan<char> statement)
-        => statement.StartsWith("INSERT", StringComparison.OrdinalIgnoreCase)
-            || statement.StartsWith("UPDATE", StringComparison.OrdinalIgnoreCase)
-            || statement.StartsWith("DELETE", StringComparison.OrdinalIgnoreCase)
-            || statement.StartsWith("MERGE", StringComparison.OrdinalIgnoreCase)
-            || statement.StartsWith("CREATE", StringComparison.OrdinalIgnoreCase)
-            || statement.StartsWith("ALTER", StringComparison.OrdinalIgnoreCase)
-            || statement.StartsWith("DROP", StringComparison.OrdinalIgnoreCase)
-            || statement.StartsWith("TRUNCATE", StringComparison.OrdinalIgnoreCase);
 }

--- a/src/QueryGuard.EntityFrameworkCore/SqlCommandClassifier.cs
+++ b/src/QueryGuard.EntityFrameworkCore/SqlCommandClassifier.cs
@@ -1,0 +1,153 @@
+using System;
+
+namespace QueryGuard.EntityFrameworkCore;
+
+/// <summary>
+/// Recognizes modification keywords at statement boundaries without treating literal content as SQL.
+/// </summary>
+internal static class SqlCommandClassifier
+{
+    internal static bool ContainsModification(string sql)
+    {
+        var index = 0;
+        var statementStart = true;
+
+        while (index < sql.Length)
+        {
+            var current = sql[index];
+            if (char.IsWhiteSpace(current))
+            {
+                index++;
+                continue;
+            }
+
+            if (current == '-' && Peek(sql, index + 1) == '-')
+            {
+                index += 2;
+                while (index < sql.Length && sql[index] is not '\r' and not '\n')
+                {
+                    index++;
+                }
+
+                continue;
+            }
+
+            if (current == '/' && Peek(sql, index + 1) == '*')
+            {
+                index = SkipBlockComment(sql, index);
+                continue;
+            }
+
+            if (current == ';')
+            {
+                statementStart = true;
+                index++;
+                continue;
+            }
+
+            if (current == '\'')
+            {
+                index = SqlStringLiteralScanner.SingleQuotedEnd(sql, index);
+            }
+            else if (current is '"' or '`' or '[')
+            {
+                index = SkipDelimited(sql, index, current == '[' ? ']' : current);
+            }
+            else if (current == '$' && SqlStringLiteralScanner.TryDollarQuotedEnd(sql, index, out var end))
+            {
+                index = end;
+            }
+            else if (statementStart)
+            {
+                var start = index;
+                while (index < sql.Length && IsIdentifierPart(sql[index]))
+                {
+                    index++;
+                }
+
+                if (IsModificationKeyword(sql.AsSpan(start, index - start)))
+                {
+                    return true;
+                }
+
+                if (index == start)
+                {
+                    index++;
+                }
+            }
+            else
+            {
+                index++;
+            }
+
+            statementStart = false;
+        }
+
+        return false;
+    }
+
+    private static int SkipDelimited(string sql, int opening, char closing)
+    {
+        var index = opening + 1;
+        while (index < sql.Length)
+        {
+            if (sql[index] == closing)
+            {
+                if (Peek(sql, index + 1) != closing)
+                {
+                    return index + 1;
+                }
+
+                index += 2;
+                continue;
+            }
+
+            index++;
+        }
+
+        return sql.Length;
+    }
+
+    private static int SkipBlockComment(string sql, int opening)
+    {
+        var depth = 1;
+        var index = opening + 2;
+        while (index < sql.Length)
+        {
+            if (sql[index] == '/' && Peek(sql, index + 1) == '*')
+            {
+                depth++;
+                index += 2;
+            }
+            else if (sql[index] == '*' && Peek(sql, index + 1) == '/')
+            {
+                index += 2;
+                if (--depth == 0)
+                {
+                    return index;
+                }
+            }
+            else
+            {
+                index++;
+            }
+        }
+
+        return sql.Length;
+    }
+
+    private static char Peek(string sql, int index) => index < sql.Length ? sql[index] : '\0';
+
+    private static bool IsIdentifierPart(char value)
+        => char.IsAsciiLetterOrDigit(value) || value >= '\u0080' || value is '_' or '@' or '$' or '#';
+
+    private static bool IsModificationKeyword(ReadOnlySpan<char> token)
+        => token.Equals("INSERT", StringComparison.OrdinalIgnoreCase)
+            || token.Equals("UPDATE", StringComparison.OrdinalIgnoreCase)
+            || token.Equals("DELETE", StringComparison.OrdinalIgnoreCase)
+            || token.Equals("MERGE", StringComparison.OrdinalIgnoreCase)
+            || token.Equals("CREATE", StringComparison.OrdinalIgnoreCase)
+            || token.Equals("ALTER", StringComparison.OrdinalIgnoreCase)
+            || token.Equals("DROP", StringComparison.OrdinalIgnoreCase)
+            || token.Equals("TRUNCATE", StringComparison.OrdinalIgnoreCase);
+}

--- a/tests/QueryGuard.EntityFrameworkCore.Tests/CommandClassificationTests.cs
+++ b/tests/QueryGuard.EntityFrameworkCore.Tests/CommandClassificationTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Threading.Tasks;
 using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
@@ -42,6 +43,10 @@ public class CommandClassificationTests
     [InlineData("INSERT INTO \"T\" (\"A\") VALUES (@p0) RETURNING \"Id\";")]
     // A leading declaration, which SQL Server emits when an insert needs an OUTPUT table.
     [InlineData("DECLARE @inserted0 TABLE ([Id] int);\nINSERT INTO [T] ([A]) OUTPUT INSERTED.[Id] INTO @inserted0 VALUES (@p0);")]
+    [InlineData("SET NOCOUNT ON; /* tagged write */ UPDATE [T] SET [A] = @p0;")]
+    [InlineData("/* outer /* inner */ still comment */ DELETE FROM [T];")]
+    [InlineData("SELECT ';UPDATE'; DELETE FROM [T];")]
+    [InlineData("SELECT [a]];DELETE] FROM [T]; UPDATE [T] SET [A] = @p0;")]
     public async Task A_write_behind_a_directive_prologue_is_not_a_read(string commandText)
     {
         var record = await ExecuteAsync(commandText, expectSuccess: false);
@@ -52,6 +57,12 @@ public class CommandClassificationTests
     [Theory]
     [InlineData("SELECT [A] FROM [T] WHERE [Id] = @p0;")]
     [InlineData("SET NOCOUNT ON;\nSELECT [A] FROM [T];")]
+    [InlineData("SELECT $$;DELETE$$ FROM [T];")]
+    [InlineData("SELECT $tag$;UPDATE$tag$ FROM [T];")]
+    [InlineData("SELECT E'prefix\\';DELETE' FROM [T];")]
+    [InlineData("SELECT [a]];DELETE] FROM [T];")]
+    [InlineData("SELECT /* outer /* inner */ ;DELETE */ [A] FROM [T];")]
+    [InlineData("DELETE_LOG @p0;")]
     public async Task A_read_stays_a_read(string commandText)
     {
         var record = await ExecuteAsync(commandText, expectSuccess: false);
@@ -86,9 +97,10 @@ public class CommandClassificationTests
             {
                 _ = await db.Database.ExecuteSqlRawAsync(commandText);
             }
-            catch (SqliteException) when (!expectSuccess)
+            catch (Exception exception) when (!expectSuccess && exception is SqliteException or InvalidOperationException)
             {
-                // Expected: the statement is here for its shape, not to run.
+                // Expected: the statement is here for its shape, not to run. PostgreSQL dollar
+                // quotes can look like unbound SQLite parameters and raise InvalidOperationException.
             }
         }
 

--- a/tests/QueryGuard.EntityFrameworkCore.Tests/ReadClassificationRegressionTests.cs
+++ b/tests/QueryGuard.EntityFrameworkCore.Tests/ReadClassificationRegressionTests.cs
@@ -1,0 +1,88 @@
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using QueryGuard.Testing;
+using Xunit;
+
+namespace QueryGuard.EntityFrameworkCore.Tests;
+
+public class ReadClassificationRegressionTests
+{
+    [Theory]
+    [InlineData("SELECT ';DELETE' AS \"Value\"")]
+    [InlineData("SELECT 'text'';UPDATE' AS \"Value\"")]
+    [InlineData("SELECT 'ok' /* ;DELETE FROM T */ AS \"Value\"")]
+    [InlineData("SELECT 'ok' -- ;TRUNCATE T\n AS \"Value\"")]
+    [InlineData("SELECT \"a;DROP\" AS \"Value\" FROM (SELECT 'ok' AS \"a;DROP\")")]
+    [InlineData("SELECT [a;ALTER] AS \"Value\" FROM (SELECT 'ok' AS [a;ALTER])")]
+    [InlineData("SELECT `a;INSERT` AS \"Value\" FROM (SELECT 'ok' AS `a;INSERT`)")]
+    [InlineData("SELECT \"a\"\";DELETE\" AS \"Value\" FROM (SELECT 'ok' AS \"a\"\";DELETE\")")]
+    [InlineData("SELECT `a``;DELETE` AS \"Value\" FROM (SELECT 'ok' AS `a``;DELETE`)")]
+    public async Task Reads_with_sql_syntax_inside_values_identifiers_or_comments_consume_the_budget(string sql)
+    {
+        await using var connection = new SqliteConnection("Data Source=:memory:");
+        await connection.OpenAsync();
+        var options = new DbContextOptionsBuilder<DbContext>().UseSqlite(connection).UseQueryGuard().Options;
+        await using var db = new DbContext(options);
+
+        foreach (var asynchronous in new[] { false, true })
+        {
+            await using var scope = QueryGuardScope.Start("read", QueryGuardPolicy.Create("read").WithMaxQueries(0));
+            var query = db.Database.SqlQueryRaw<string>(sql);
+            var values = asynchronous ? await query.ToListAsync() : query.ToList();
+            Assert.Single(values);
+
+            var result = await scope.CompleteAsync();
+            Assert.Equal(QueryCommandKind.Reader, Assert.Single(result.Records).Kind);
+            Assert.Equal(1, result.ReadCommandCount);
+            Assert.Throws<QueryGuardBudgetExceededException>(() => QueryGuardAssert.Passes(result));
+        }
+    }
+
+    [Theory]
+    [InlineData("SELECT ';DELETE' FROM \"Missing\"")]
+    [InlineData("SELECT [a;DROP] FROM \"Missing\"")]
+    [InlineData("SELECT * /* ;UPDATE T */ FROM \"Missing\"")]
+    public async Task Failed_reads_keep_the_original_exception_and_read_count(string sql)
+    {
+        await using var connection = new SqliteConnection("Data Source=:memory:");
+        await connection.OpenAsync();
+        var options = new DbContextOptionsBuilder<DbContext>().UseSqlite(connection).UseQueryGuard().Options;
+        await using var db = new DbContext(options);
+        await using var scope = QueryGuardScope.Start("failed read", QueryGuardPolicy.Create("read"));
+
+        await Assert.ThrowsAsync<SqliteException>(() => db.Database.SqlQueryRaw<string>(sql).ToListAsync());
+
+        var result = await scope.CompleteAsync();
+        var record = Assert.Single(result.Records);
+        Assert.True(record.IsFailed);
+        Assert.Equal(QueryCommandKind.Reader, record.Kind);
+        Assert.Equal(1, result.ReadCommandCount);
+    }
+
+    [Theory]
+    [InlineData("-- QueryGuard:Ignore reason=seed\nINSERT INTO Writes DEFAULT VALUES RETURNING Id AS Value")]
+    [InlineData("/* write with ;SELECT inside a comment */ INSERT INTO Writes DEFAULT VALUES RETURNING Id AS Value")]
+    public async Task Writes_with_leading_comments_and_returning_rows_do_not_consume_read_budgets(string sql)
+    {
+        await using var connection = new SqliteConnection("Data Source=:memory:");
+        await connection.OpenAsync();
+        var options = new DbContextOptionsBuilder<DbContext>().UseSqlite(connection).UseQueryGuard().Options;
+        await using var db = new DbContext(options);
+        await db.Database.ExecuteSqlRawAsync("CREATE TABLE Writes (Id INTEGER PRIMARY KEY)");
+
+        foreach (var asynchronous in new[] { false, true })
+        {
+            await using var scope = QueryGuardScope.Start("write", QueryGuardPolicy.Create("write").WithMaxQueries(0));
+            var query = db.Database.SqlQueryRaw<int>(sql);
+            var values = asynchronous ? await query.ToListAsync() : query.ToList();
+            Assert.Single(values);
+
+            var result = await scope.CompleteAsync();
+            Assert.Equal(QueryCommandKind.NonQuery, Assert.Single(result.Records).Kind);
+            Assert.Equal(0, result.ReadCommandCount);
+            QueryGuardAssert.Passes(result);
+        }
+    }
+}

--- a/tests/QueryGuard.ProviderTests/PostgreSqlProviderTests.cs
+++ b/tests/QueryGuard.ProviderTests/PostgreSqlProviderTests.cs
@@ -216,6 +216,32 @@ public sealed class PostgreSqlProviderTests : IAsyncLifetime
     private static QueryGuardSession NewSession()
         => new("provider-test", QueryGuardPolicy.Create("provider"));
 
+    [DockerFact]
+    public async Task Sql_tokens_inside_postgres_strings_and_nested_comments_still_count_as_reads()
+    {
+        await using var context = CreateContext();
+        var session = NewSession();
+        string[] statements =
+        [
+            "SELECT $$;DELETE$$ AS \"Value\"",
+            "SELECT $tag$;UPDATE$tag$ AS \"Value\"",
+            "SELECT E'prefix\\';DELETE' AS \"Value\"",
+            "SELECT 'ok' /* outer /* inner */ ;DROP */ AS \"Value\"",
+        ];
+
+        using (_accessor.Activate(session))
+        {
+            foreach (var sql in statements)
+            {
+                Assert.Single(await context.Database.SqlQueryRaw<string>(sql).ToListAsync());
+            }
+        }
+
+        var completed = session.Complete();
+        Assert.Equal(statements.Length, completed.CountedCommandCount);
+        Assert.All(completed.Records, record => Assert.Equal(QueryCommandKind.Reader, record.Kind));
+    }
+
     private ProviderDbContext CreateContext()
     {
         var options = new DbContextOptionsBuilder<ProviderDbContext>()


### PR DESCRIPTION
## What changed

`SELECT ';DELETE' AS "Value"` previously counted as zero reads because the classifier treated the semicolon inside the string as a statement boundary. It now counts as one read and fails a zero-read budget.

Scan statement boundaries while skipping strings, escaped quoted identifiers, and line/block comments. Reuse the existing string scanner for PostgreSQL dollar quotes and escape strings. Require complete write keywords, and recognize writes after leading comments. SQL Server directive batches keep their existing write classification.

## Why

Read commands must count toward query budgets even when values or comments contain SQL-looking text. Execution results and original database exceptions stay unchanged. This remains a lexical check; CTEs and stored procedure bodies are not parsed. Public APIs and report schemas are unchanged.

## How it was tested

- 22 regression cases failed against the original classifier; all 55 EF Core tests pass with the fix.
- Successful reads and writes are tested synchronously and asynchronously against SQLite, including actual budget assertions. Failed reads preserve the SQLite exception and count as reads.
- Added a real PostgreSQL regression test for dollar quotes, escape strings, and nested comments.
- `dotnet build QueryGuard.slnx -c Release`: .NET 8 and 10, zero warnings/errors.
- `dotnet test QueryGuard.slnx -c Release -f net10.0 --no-build --no-restore`: 566 passed, 27 skipped (26 Docker tests and one sample maintenance helper).
- `dotnet format QueryGuard.slnx --verify-no-changes --no-restore` and `git diff --check` passed.
- All 22 existing benchmark cases completed with `--job Dry` (smoke check only).

Docker is unavailable locally and the .NET 8 runtime is not installed; live PostgreSQL execution and .NET 8 tests remain for CI.

Three commits: regression tests, classifier fix, documentation.