### PR TITLE
docs: simplify the documentation in plain English

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,47 +1,26 @@
 # QueryGuard.NET documentation
 
-## Using QueryGuard
+Start with the [quick start](./index.md), or read the [published docs](https://benziza.github.io/queryguard-dotnet/).
 
-- [How it works](./concepts/README.md): sessions, the stateless interceptor, fingerprints, redaction,
-  and analysis, in the order a command travels through them.
-- [Testing](./testing/README.md): measure `WebApplicationFactory` requests or open an explicit scope
-  around a service or background job.
-- [Public project validation](./case-studies/public-project-validation.md): results from three public
-  ASP.NET Core test suites, including the package problem the work found.
-- [Configuration](./configuration/README.md): every budget and option, what it defaults to, and the
-  reasoning behind each default.
-- [Baselines](./baselines/README.md): record what a scope costs today and report what changed, so
-  nobody has to guess a budget number.
-- [Troubleshooting](./troubleshooting/README.md): nothing recorded, fingerprints not grouping,
-  `(unmatched)` scope names, dropped commands.
-- [When a finding is wrong](./troubleshooting/false-positives.md): what repeated SQL does and does not
-  prove, and the four ways to record an intentional exception.
-- [Provider support](./providers/README.md): what is integration-tested, what is fixture-verified,
-  and why those are different claims.
-- [Benchmarks](./benchmarks.md): what QueryGuard costs on the command path, with raw output and the
-  reasons not to turn any of it into a production latency figure.
+## Guides
 
-## Understanding the design
+- [Testing](./testing/README.md): measure requests, services, and jobs.
+- [Configuration](./configuration/README.md): query limits and capture settings.
+- [Baselines](./baselines/README.md): compare query counts between runs.
+- [Troubleshooting](./troubleshooting/README.md): fix setup and reporting problems.
+- [When a finding is wrong](./troubleshooting/false-positives.md): allow intentional repetition.
+- [How it works](./concepts/README.md): sessions, fingerprints, and analysis.
+- [Provider support](./providers/README.md): tested databases and known limits.
+- [Benchmarks](./benchmarks.md): measured costs and raw results.
+- [Public project validation](./case-studies/public-project-validation.md): compatibility results.
+- [API reference](./api/index.md): types and methods.
 
-- [Architecture decision records](./decisions/README.md): why QueryGuard behaves the way it does, and
-  what would make each decision change. The most complete explanation of the design.
-- [Roadmap](./roadmap.md): what v0.1 covers, what it deliberately does not, and how priority is
-  decided.
+## Contributors
 
-## For contributors
-
-- [CONTRIBUTING.md](../CONTRIBUTING.md): workflow, branch and commit conventions, and how to get a
-  change merged.
-- [Coding standards](./coding-standards.md): the rules that come up in review, with the reasoning
-  behind them.
-- [Testing strategy](./testing-strategy.md): the layers, the critical scenarios that must never
-  regress, and the benchmark honesty rules.
-- [Review checklist](./review-checklist.md): prompts for changes that touch capture, redaction,
-  the hot path, or the public API. Not required for a pull request.
-- [Releasing](./releasing.md): one-time setup, the per-release checklist, and
-  what to do when a publish goes wrong.
-
-## Assets
-
-`assets/` holds the logo, package icon, and social preview image. They are generated from simple shapes
-rather than a design tool so they stay editable and reviewable in a diff.
+- [Contributing](https://github.com/Benziza/queryguard-dotnet/blob/main/CONTRIBUTING.md)
+- [Coding standards](./coding-standards.md)
+- [Testing strategy](./testing-strategy.md)
+- [Review checklist](./review-checklist.md)
+- [Releasing](./releasing.md)
+- [Roadmap](./roadmap.md)
+- [Design decisions](./decisions/README.md)

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -1,29 +1,26 @@
 ---
 title: API reference
-description: The public API of every QueryGuard.NET package, generated from the source.
+description: QueryGuard.NET types and methods, generated from source.
 ---
 
 # API reference
 
-Generated from the source and its XML documentation, so what you read here is what the compiler sees.
+Browse types and methods generated from the source documentation.
 
-| Namespace | What lives there |
+| Namespace | Includes |
 | --- | --- |
-| `QueryGuard` | The core model: sessions, policies, results, findings, fingerprints, redaction, baselines |
-| `QueryGuard.EntityFrameworkCore` | `UseQueryGuard`, the command interceptor, the session accessor |
-| `QueryGuard.Testing` | `QueryGuardScope` and `QueryGuardAssert`: the two types most projects touch |
-| `QueryGuard.Reporting` | Console, JSON, JUnit, and Markdown reporters, and the report reader |
-| `QueryGuard.AspNetCore` | Per-request capture middleware for a running application |
+| `QueryGuard` | Sessions, policies, results, fingerprints, redaction, and baselines |
+| `QueryGuard.EntityFrameworkCore` | EF Core registration and command capture |
+| `QueryGuard.Testing` | Test scopes and assertions |
+| `QueryGuard.Reporting` | Report writers and readers |
+| `QueryGuard.AspNetCore` | Request middleware |
 
-Start from [`QueryGuardScope`](QueryGuard.Testing.QueryGuardScope.yml) and
-[`QueryGuardAssert`](QueryGuard.Testing.QueryGuardAssert.yml) if you are writing a test, or
-[`QueryGuardPolicy`](QueryGuard.QueryGuardPolicy.yml) to see every budget you can set.
+Start with [`QueryGuardScope`](QueryGuard.Testing.QueryGuardScope.yml),
+[`QueryGuardAssert`](QueryGuard.Testing.QueryGuardAssert.yml), or
+[`QueryGuardPolicy`](QueryGuard.QueryGuardPolicy.yml).
 
-> [!NOTE]
-> Preview. The API will change before `1.0.0`, and the
-> [versioning policy](../decisions/0011-versioning.md) says what that means in practice. The report JSON
-> carries its own `schemaVersion` so a breaking change to the format is a visible event rather than a
-> surprise.
+For HTTP integration tests, see the [testing guide](../testing/README.md).
+For CLI commands, see [baselines](../baselines/README.md).
 
-`QueryGuard.Cli` is not listed: it is the `dotnet queryguard` tool, and every type in it is internal.
-Its interface is its command line, documented under [baselines](../baselines/README.md).
+API and report compatibility follow the [versioning policy](../decisions/0011-versioning.md).
+JSON reports include a `schemaVersion` field.

--- a/docs/baselines/README.md
+++ b/docs/baselines/README.md
@@ -1,21 +1,46 @@
 # Baselines
 
-A query budget asks you for a number you probably do not have. `WithMaxQueries(10)` needs someone to
-know that ten is right, and on an endpoint nobody has measured, nobody does, so the number gets
-guessed, or set high enough never to fire, or set low and then raised until the build goes green.
-
-A baseline asks for nothing. It records what the code does today and reports what changed.
+A baseline saves current query counts. Later runs show what changed:
 
 ```text
 GET /api/companies
   3 -> 51 queries
 ```
 
-No threshold, no judgement needed to read it. And it is the shape of the thing a reviewer actually
-cares about: not *this endpoint is over budget* but *this pull request changed this endpoint*.
+Use a baseline when you do not know the right query budget yet.
+You can also use it alongside fixed budgets.
 
-Budgets and baselines are complementary. A budget is a line you refuse to cross. A baseline notices you
-moved.
+## Record and verify with the CLI
+
+Install the tool:
+
+```bash
+dotnet tool install -g QueryGuard.Cli
+```
+
+Have your tests write JSON reports:
+
+```csharp
+await new QueryGuardJsonReporter().WriteAsync(result, "artifacts/queryguard/companies.json");
+```
+
+Run the tests, then record the baseline:
+
+```bash
+queryguard baseline record
+```
+
+Commit `queryguard-baseline.json`. After later test runs, compare the new reports:
+
+```bash
+queryguard verify --summary artifacts/queryguard/summary.md
+```
+
+Add `--fail-on-regression` to return a non-zero exit code when counts increase.
+Without it, regressions are reported but do not fail the command.
+
+The CLI reads reports; it does not run tests. Recording updates measured scopes and keeps
+other baseline entries. Files that are not QueryGuard reports are skipped.
 
 ## The file
 
@@ -33,14 +58,9 @@ moved.
 }
 ```
 
-Counts only: no SQL, no timings. SQL would make the file a second copy of the report and would produce
-a diff on every unrelated schema change. Timings vary between a laptop and a busy runner, so a baseline
-containing them would report a regression whenever CI was loaded, which is how a check earns being
-ignored.
+The file stores counts, not SQL or timings. Entries are sorted by scope name.
 
-Entries are ordered by scope and the file ends with a newline, so its diff is reviewable. Commit it.
-
-## Recording one
+## Recording one in code
 
 ```csharp
 var baseline = QueryGuardBaseline.Empty;
@@ -53,8 +73,7 @@ foreach (var result in measuredResults)
 File.WriteAllText("queryguard-baseline.json", baseline.ToJson());
 ```
 
-`QueryGuardBaseline` is immutable. `Record` returns a new instance, so building one across a test run
-is safe without locking.
+`Record` returns a new baseline. Keep its return value.
 
 ## Comparing against one
 
@@ -64,61 +83,15 @@ var comparison = QueryGuardBaselineComparison.Compare(baseline, measuredResults)
 
 if (comparison.HasRegressions)
 {
-    // Your call. Fail the test, warn, or just publish the table.
+    // Fail the test, log a warning, or publish a report.
 }
 ```
 
-`Compare` does not fail anything. More queries is a fact; whether it is a defect is a judgement, and
-the library does not get to make it: the same reason a repeated-query finding is a warning rather than
-a failure.
-
-## Without writing any plumbing
-
-The library can do all of this from a test. The command-line tool does the file handling for you:
-
-```bash
-dotnet tool install -g QueryGuard.Cli
-```
-
-Have the test run write JSON reports:
-
-```csharp
-await new QueryGuardJsonReporter().WriteAsync(result, "artifacts/queryguard/companies.json");
-```
-
-Record once, and commit the file:
-
-```bash
-queryguard baseline record
-```
-
-Then on every run:
-
-```bash
-queryguard verify --summary artifacts/queryguard/summary.md
-```
-
-```text
-2 report(s), 2 scope(s) compared.
-  REGRESSION GET /api/companies: 3 -> 51
-             GET /api/users: unchanged
-
-1 scope(s) run more queries than the baseline.
-If that is intended, re-record the baseline and commit it.
-```
-
-Add `--fail-on-regression` to make that exit non-zero. Without it the tool reports and exits 0, because
-more queries is a fact and whether it is a defect is a judgement.
-
-Recording **merges** rather than replaces, so a run that measured three endpoints does not delete the
-baseline for every endpoint it did not exercise. Files that are not QueryGuard reports are skipped, so a
-coverage file in the same directory does not stop the run.
-
-The tool does not run your tests. Measurement happens in the test process where the `DbContext` lives; a
-tool that owned that would have to guess your test command, your target framework, and your fixture
-wiring.
+`Compare` returns results without throwing for regressions.
 
 ## In a pull request
+
+Render a Markdown summary:
 
 ```csharp
 var markdown = new QueryGuardBaselineMarkdownReporter().Render(comparison);
@@ -130,48 +103,27 @@ if (summary is not null)
 }
 ```
 
-Which produces this on the workflow run page:
+| Scope | Before | Now | Change |
+| --- | --: | --: | --- |
+| `GET /api/companies` | 3 | 51 | +48, most-repeated query +48 |
+| `GET /api/orders` | 8 | 8 | most-repeated query +7 |
+| `GET /api/users` | 4 | 4 | unchanged |
+| `GET /api/reports` | 12 | 3 | -9 (improved) |
 
-> ### QueryGuard
->
-> **2 scopes now run more queries than the baseline.** `GET /api/companies` went from 3 to 51.
->
-> | Scope | Before | Now | Change |
-> | --- | --: | --: | --- |
-> | `GET /api/companies` | 3 | 51 | +48, most-repeated query +48 |
-> | `GET /api/orders` | 8 | 8 | most-repeated query +7 |
-> | `GET /api/invoices` | - | 3 | new scope |
-> | `GET /api/users` | 4 | 4 | unchanged |
-> | `GET /api/reports` | 12 | 3 | -9 (improved) |
+A stable total can still hide more repetition, as the `orders` row shows.
+The baseline tracks the highest occurrence count separately.
 
-The `GET /api/orders` row is the one worth looking at twice. The read count did not move: **8 before,
-8 now**, but one query is now running seven more of them than it used to. Twenty distinct lookups
-becoming one query repeated twenty times leaves a total-count budget perfectly satisfied. That is why
-`topFingerprintOccurrences` is stored separately.
+For a pull request comment, see the
+[GitHub Action setup](https://github.com/Benziza/queryguard-dotnet/blob/main/action/README.md).
 
-## Rules that keep it usable
+## Comparison rules
 
-**A new scope is not a regression.** Otherwise the pull request that adds any endpoint fails for adding
-it, and the check gets disabled by the second person who hits it.
+- New scopes are shown as new, not as regressions.
+- Scopes missing from a run are ignored.
+- Lower counts are reported as improvements.
+- To accept an intended increase, record again and commit the diff.
+- Renaming a scope makes it a new entry; names are the comparison key.
+- Unsupported future schema versions are rejected.
+- To resolve a baseline merge conflict, rerun the relevant tests and record their results.
 
-**A scope missing from the run is ignored, not reported as removed.** A filtered test run would
-otherwise claim every endpoint it did not exercise had been deleted.
-
-**Improvements are reported too.** A pull request that fixes an N+1 gets to show it. A tool that only
-delivers bad news is one people stop reading.
-
-**Accepting a regression is deliberate.** Regenerate the file and commit it. The diff then shows a
-reviewer that a scope went from 3 to 51 and somebody decided that was fine, which is a much better
-record than a threshold quietly raised in a config file.
-
-## Things to know
-
-- **The file will occasionally conflict on merge.** It is generated and ordered, so regenerating is
-  always a valid resolution.
-- **Renaming a route loses that scope's history.** Scope names are the join key, so a rename reads as
-  one scope disappearing and another appearing: both non-events by the rules above.
-- **A future schema version is rejected, not guessed at.** Reading a baseline wrong is worse than
-  refusing to read it: a silently empty baseline reports every scope as new, which hides every
-  regression in the run.
-
-The reasoning behind all of this is in [ADR-0013](../decisions/0013-baseline-storage.md).
+See [baseline design](../decisions/0013-baseline-storage.md) for details.

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -1,21 +1,27 @@
 # Benchmarks
 
-QueryGuard runs on the database command path, so "what does it cost?" deserves a measured answer rather
-than an assurance. This page is that answer, with the environment that produced it and the caveats that
-limit it.
+These benchmarks measure QueryGuard code with generated SQL. They do not include a database,
+network, HTTP request, or EF Core command execution.
 
-## How to read this page
-
-**These are microbenchmarks.** They measure QueryGuard's own code in isolation, with no database, no
-network, and no HTTP pipeline. A real EF Core query against a real database takes hundreds of
-microseconds to milliseconds; the numbers below are nanoseconds. Do not convert them into a percentage
-of request latency: that requires measuring *your* application, and the honest statement is that this
-page cannot tell you what QueryGuard costs in production.
-
-What it *can* tell you is the relative cost of QueryGuard's own choices, which is what the design
-decisions rest on.
+Use them to compare capture options. Measure your application to estimate request overhead.
+Short runs have wide error margins; treat these results as estimates.
 
 ## Environment
+
+The following tables, except the full SQL update, use this environment:
+
+| Setting | Value |
+| --- | --- |
+| Source | [`46ec17e`](https://github.com/Benziza/queryguard-dotnet/commit/46ec17ebb9704694e71eb67f73ead60e5556ecca) |
+| Date | 2026-08-20 |
+| BenchmarkDotNet | 0.15.8 |
+| Job | ShortRun: 3 warmup iterations, 3 measured iterations, 1 launch |
+| OS | Windows 11 (10.0.26200.9168/25H2) |
+| CPU | Intel Core Ultra 5 225F, 3.30 GHz, 10 physical / 10 logical cores |
+| Runtime | SDK 10.0.302, .NET 10.0.10, X64 RyuJIT `x86-64-v3` |
+| EF Core / provider | Not exercised / none |
+
+[Raw reports and CSV files](https://github.com/Benziza/queryguard-dotnet/tree/main/docs/benchmarks/2026-08-20-46ec17e)
 
 Reproduce with:
 
@@ -23,53 +29,18 @@ Reproduce with:
 dotnet run -c Release --project benchmarks/QueryGuard.Benchmarks -- --filter "*" --job Short
 ```
 
-| | |
-| --- | --- |
-| Source commit | [`46ec17e`](https://github.com/Benziza/queryguard-dotnet/commit/46ec17ebb9704694e71eb67f73ead60e5556ecca) |
-| Measured on | 2026-08-20 |
-| BenchmarkDotNet | 0.15.8 |
-| Job | `ShortRun`: 3 warmup, 3 iterations, 1 launch |
-| OS | Windows 11 (10.0.26200.9168/25H2) |
-| CPU | Intel Core Ultra 5 225F, 3.30 GHz, 10 physical / 10 logical cores |
-| SDK | .NET 10.0.302, host .NET 10.0.10, X64 RyuJIT `x86-64-v3` |
-| EF Core | Not exercised; see below |
-| Provider | None: these are in-process only |
+Use the default benchmark job on a quiet machine for more reliable measurements.
+CI uses `--job Dry` only to check that the benchmarks run.
 
-**EF Core is not on the measured path.** The benchmark project references it, but every scenario here
-drives QueryGuard's own types directly with pre-generated SQL strings. That is deliberate: including a
-real query would measure SQLite, not QueryGuard, and the interesting question is what QueryGuard adds.
-The cost of EF Core calling an interceptor at all belongs to EF Core.
+## No active scope
 
-**`ShortRun` was used deliberately**, and it matters: three iterations produce wide error margins,
-visible in the raw output where `Error` sometimes exceeds the mean. Treat every figure below as an order
-of magnitude, not a measurement. A number worth quoting publicly needs a default-job run on a quiet
-machine; this page exists to support design decisions, and for that the ratios are enough.
-
-**Raw output is published with the summary**:
-[`docs/benchmarks/2026-08-20-46ec17e/`](https://github.com/Benziza/queryguard-dotnet/tree/main/docs/benchmarks/2026-08-20-46ec17e) holds the GitHub-format
-tables and CSV exactly as BenchmarkDotNet wrote them, including the full environment header. A summary
-table without its raw output is a number nobody can check. CI also runs every benchmark once per pull
-request with `--job Dry` and uploads the artifacts: that proves the harness still runs, and nothing
-about timing.
-
-## Being installed costs nothing measurable
-
-The most important number here. This is what QueryGuard costs per command when it is registered but no
-scope is open: every request outside a measured path, and every request at all when
-`Enabled = false`.
+This measures the session lookup when no scope is open.
 
 | Commands | Mean | Allocated |
 | --- | --- | --- |
 | 1 | 1.11 ns | 0 B |
 | 10 | 7.35 ns | 0 B |
 | 100 | 91.81 ns | 0 B |
-
-About a nanosecond per command, zero allocation. That is one `AsyncLocal` read and a null check, which
-is the whole cost of the "stateless interceptor plus ambient accessor" design in
-[ADR-0002](./decisions/0002-session-propagation.md).
-
-It also supports the claim that installing QueryGuard does not change how an application behaves. If
-this row were expensive, that claim would be false.
 
 ## Capturing and analysing a scope
 
@@ -79,17 +50,12 @@ this row were expensive, that claim would be false.
 | 10 | 770 ns | 1,359 ns | 4,488 B |
 | 100 | 5,586 ns | 7,064 ns | 15,728 B |
 
-Per-command cost falls as the scope grows: roughly 270 ns for a single command, 77 ns each at ten, 56 ns
-each at a hundred, because the fixed cost of opening a scope amortises. Analysis adds between a quarter
-and three quarters on top depending on scope size, and it happens once when the scope closes rather than
-per command.
-
-At a hundred commands the whole scope costs about 7 µs. A hundred real database round trips cost several
-orders of magnitude more than that.
+Analysis runs once when the scope ends. These capture measurements do not include
+the separate fingerprint work below.
 
 ## Fingerprinting
 
-Normalize, redact, then hash: the work done once per intercepted command.
+Results at the August source revision:
 
 | Columns in the statement | Full | Normalize only | Redact only |
 | --- | --- | --- | --- |
@@ -97,29 +63,20 @@ Normalize, redact, then hash: the work done once per intercepted command.
 | 20 | 1,138 ns | 486 ns | 482 ns |
 | 200 | 7,199 ns | 3,189 ns | 3,459 ns |
 
-Cost grows with SQL length and no faster, which is what a single-pass scanner should do. A quadratic
-pass would put the 200-column row at far more than ten times the 20-column row; it is at about six
-times.
-
-Normalization and redaction cost about the same as each other, so neither is a hot spot to attack if
-this ever needs optimising. The remainder is hashing, whose fixed cost is a noticeable share of a short
-statement and almost nothing on a long one.
-
-The 200-column row is a wide report query, not a typical one. A keyed lookup is the 3-column row.
-
 ## Full SQL fingerprints (2026-09-05)
 
-This run measures complete redacted SQL hashing before display truncation at
+This update measures hashing the full redacted SQL before display truncation at
 [`aa8f6f8`](https://github.com/Benziza/queryguard-dotnet/commit/aa8f6f829de774d46c4badb77c10633c09ec9feb).
 The 700-column case exceeds the default 4096-character display limit.
+
+Environment: Windows 11 (10.0.26200.9168), Intel Core Ultra 5 225F (10 cores),
+SDK 10.0.400, .NET 10.0.11, BenchmarkDotNet 0.15.8.
+ShortRun used one launch, three warmup iterations, and three measured iterations.
+No database or EF Core command execution was involved.
 
 ```bash
 dotnet run -c Release --project benchmarks/QueryGuard.Benchmarks -- --filter "*FingerprintBenchmarks.FullFingerprint*" --job Short
 ```
-
-Measured on Windows 11 (10.0.26200.9168), Intel Core Ultra 5 225F (10 cores), SDK 10.0.400,
-.NET 10.0.11, with BenchmarkDotNet 0.15.8. `ShortRun` uses one launch, three warmup iterations,
-and three measured iterations. No database or EF Core command execution is involved.
 
 | Columns | Mean | Error (99.9% CI half-width) | Allocated per operation |
 | --- | --- | --- | --- |
@@ -128,44 +85,18 @@ and three measured iterations. No database or EF Core command execution is invol
 | 200 | 9.05 us | 3.11 us | 36.85 KB |
 | 700 | 29.93 us | 8.91 us | 136.26 KB |
 
-Full-text hashing processes the complete redacted statement even when report text is shortened.
-These short-run estimates describe this environment; the earlier tables use their recorded source
-revision and environment. The [BenchmarkDotNet report](./benchmarks/2026-09-05-aa8f6f8/QueryGuard.Benchmarks.FingerprintBenchmarks-report-github.md)
-and [CSV output](./benchmarks/2026-09-05-aa8f6f8/QueryGuard.Benchmarks.FingerprintBenchmarks-report.csv)
-include the original results and runtime details.
+[BenchmarkDotNet report](./benchmarks/2026-09-05-aa8f6f8/QueryGuard.Benchmarks.FingerprintBenchmarks-report-github.md)
+and [CSV output](./benchmarks/2026-09-05-aa8f6f8/QueryGuard.Benchmarks.FingerprintBenchmarks-report.csv).
 
 ## Stack-trace capture: why it is off by default
 
-This is the measurement [ADR-0007](./decisions/0007-stack-trace-policy.md) was waiting for.
-
-| Distinct fingerprints | Off (default) | On, first occurrence only | Slower by | More allocation by |
+| Distinct fingerprints | Off | On, first occurrence only | Slower by | More allocation by |
 | --- | --- | --- | --- | --- |
 | 1 | 722 ns | 15,720 ns | 22× | 18× |
 | 10 | 5,337 ns | 153,702 ns | 29× | 26× |
 
-Both scenarios record ten commands per fingerprint, so the *only* difference is one captured and filtered
-stack trace per distinct query.
+Each scenario records ten commands per fingerprint.
+Enabling one filtered trace per fingerprint made these scenarios 20–30 times slower.
 
-**One trace per fingerprint costs 20–30× the entire rest of the capture path, and allocates roughly 350 KB
-across ten fingerprints.** That settles the question: capture stays off by default, and the API
-deliberately offers no way to capture a trace per command: at ten commands per fingerprint that would
-be another order of magnitude.
-
-It also confirms the feature is worth keeping as an opt-in. When you are actively hunting the source of a
-repeated query, 150 µs on a development request is nothing, and knowing the call site is worth far more.
-
-What the numbers do *not* support is a claim that enabling it is cheap. It is not, and the documentation
-says so.
-
-## Claims this page does not make
-
-Per [docs/testing-strategy.md](./testing-strategy.md), the following will not appear in QueryGuard's
-documentation:
-
-- "Zero overhead": the no-scope path is close, but "close to zero" and "zero" are different claims.
-- "Negligible cost" without the number beside it.
-- "Fastest EF Core profiler": QueryGuard is not a profiler and this is not a comparison.
-- Any production latency figure derived from a microbenchmark.
-
-If you measure QueryGuard in a real application and the numbers differ from what you expected, that is
-worth an issue. Measurement from a real workload is more valuable than anything on this page.
+Request stack traces are off by default. Test scopes capture origins by default and allow
+`captureOrigin: false`. See [capture settings](./configuration/README.md#where-a-repeated-query-came-from).

--- a/docs/case-studies/public-project-validation.md
+++ b/docs/case-studies/public-project-validation.md
@@ -1,23 +1,15 @@
 # Public project validation
 
-QueryGuard `0.1.0-preview.6` was tested in three public ASP.NET Core projects before the stable
-`0.1.0` release.
-
-This is a compatibility check, not an adoption claim. The test changes stayed in local checkouts. No
-pull requests were opened in the other projects because their maintainers did not request these
-changes.
+QueryGuard `0.1.0-preview.6` was tested in local copies of three public ASP.NET Core projects.
+These checks do not imply adoption or support from their maintainers.
 
 ## Method
 
-For each project, the validation used an existing integration test setup:
+For each pinned commit below, one existing integration test setup was extended to:
 
-1. Check out the exact commit listed below.
-2. Install `QueryGuard.AspNetCore.Testing` from nuget.org.
-3. Add one `WebApplicationFactory` request test with `TrackQueries`.
-4. Set a total query budget and allow only one occurrence per fingerprint.
-5. Assert the exact query count and record the result.
-
-The final run used the published `0.1.0-preview.6` packages, not a local package feed.
+1. Install `QueryGuard.AspNetCore.Testing` from nuget.org.
+2. Measure one request with `TrackQueries`.
+3. Check the exact count and allow at most one occurrence per query ID.
 
 ## Results
 
@@ -27,30 +19,20 @@ The final run used the published `0.1.0-preview.6` packages, not a local package
 | [SSWConsulting/SSW.VerticalSliceArchitecture at `b3926fe`](https://github.com/SSWConsulting/SSW.VerticalSliceArchitecture/tree/b3926fe461fa79fd81e163d851f1dec00a5ba84e) | xUnit, SQL Server Testcontainers | `GET /api/heroes` | 2 read queries, 2 groups, 0 findings |
 | [alex289/CleanArchitecture at `70a13e3`](https://github.com/alex289/CleanArchitecture/tree/70a13e310abf8742b938a80dff48ae0735f6b5ef) | NUnit, SQL Server Testcontainers | `GET /api/v1/Tenant/{id}` | 2 read queries, 2 groups, 0 findings |
 
-The request setup worked with both NUnit and xUnit, and with SQLite and SQL Server. No QueryGuard
-false positive appeared in these three requests.
+No false positive appeared in these three requests.
 
 ## What the work found
 
-The first SSW restore failed before the test could run. `0.1.0-preview.5` required EF Core `10.0.11`,
-while the project pinned `10.0.10`. QueryGuard did not need that exact patch. [Issue #126](https://github.com/Benziza/queryguard-dotnet/issues/126)
-tracked the problem, and [pull request #127](https://github.com/Benziza/queryguard-dotnet/pull/127)
-lowered the package dependency floors. The same project restored and passed with `0.1.0-preview.6`.
-
-The alex289 request first used a total budget of one and failed with two different queries. The
-endpoint reads the tenant and its users separately. Raising the total budget to two while keeping the
-per-fingerprint limit at one represented the endpoint correctly and still guarded against repetition.
-
-The Jason Taylor checkout requested .NET SDK `10.0.400`, which was not installed on the validation
-machine. The checkout used the installed `10.0.302` feature band for this test. No QueryGuard change
-was needed.
+- **SSW:** `preview.5` required EF Core `10.0.11`, but the project used `10.0.10`.
+  [PR #127](https://github.com/Benziza/queryguard-dotnet/pull/127) lowered the dependency floor.
+  The published `preview.6` packages restored and passed.
+- **alex289:** the request reads a tenant and its users in two separate queries.
+  A total budget of two and a per-query limit of one matched this behavior.
+- **Jason Taylor:** the local check used SDK `10.0.302` instead of the requested `10.0.400`.
+  No QueryGuard change was needed.
 
 ## Limits
 
-- Only one request was tested in each project.
-- This does not measure performance or long-running application behavior.
-- Existing warnings from the projects were outside QueryGuard and were not treated as product results.
-- These local validation patches are not support commitments from the other maintainers.
-
-The validation found one packaging problem, verified its fix from nuget.org, and found no blocker for
-the stable `0.1.0` API.
+Only one request per project was tested. This does not measure performance or long-running behavior.
+The changes stayed in local checkouts; no pull requests were sent to those projects.
+Existing project warnings were outside the QueryGuard results.

--- a/docs/concepts/README.md
+++ b/docs/concepts/README.md
@@ -1,116 +1,73 @@
 # How QueryGuard works
 
-Five concepts, in the order a command travels through them.
+QueryGuard captures EF Core commands inside a scope and checks them when the scope ends.
 
 ```text
-EF Core executes a command
-        │
-        ▼
-  Interceptor ─────► asks: is a scope open?  ── no ──► do nothing
-        │ yes
-        ▼
-   Fingerprint      normalize → redact → hash
-        │
-        ▼
-    Session         append a record (that is all, per command)
-        │
-        ▼  scope closes
-    Analyzer        group by fingerprint, evaluate the policy
-        │
-        ▼
-   Result           findings, ordered, already redacted
+EF Core command
+  → Active scope?
+      No  → Skip capture
+      Yes → Normalize SQL → Redact values → Create fingerprint → Record command
+  → Scope ends → Group queries → Check policy → Return result
 ```
 
 ## 1. The session is the unit of measurement
 
-A **session** is one HTTP request or one test. It is the thing a query count is a count *of*, and
-QueryGuard has nothing useful to say without one.
+A session groups commands for one request, test, or job:
 
-Sessions come from two places:
+- `app.UseQueryGuard()` opens a session for each measured request.
+- `QueryGuardScope.Start(...)` opens an explicit scope.
+- `TrackQueries(...)` measures requests in integration tests.
 
-- `app.UseQueryGuard()` opens one per request.
-- `QueryGuardScope.Start(...)` opens one explicitly, for a test or a background job.
-
-Both nest, and the innermost wins. **No open session means no capture**: QueryGuard stays silent rather
-than guessing which scope a command belongs to.
-
-A session is mutable while open and frozen when it completes. `CompletedQueryGuardSession` is a separate
-type precisely so "a completed session cannot change" is a compile-time guarantee rather than a
-convention.
+Nested scopes capture into the innermost session. Without an active session, nothing is captured.
+A completed session cannot be changed.
 
 ## 2. The interceptor is stateless
 
-EF Core registers a `DbCommandInterceptor` as a **singleton**. One instance sees commands from every
-concurrent request, every parallel test, and every fan-out inside a single request, so it cannot hold
-per-scope state. It asks `IQueryGuardSessionAccessor` which session the command it is looking at belongs
-to.
+The interceptor observes commands without changing SQL, results, or application exceptions.
+It gets the active session from `IQueryGuardSessionAccessor`.
 
-The default accessor is backed by `AsyncLocal<T>`, which flows with `ExecutionContext`. That is what makes
-`await` boundaries and `Task.Run` fan-out land in the right session without your code passing anything
-around.
+The default accessor uses `AsyncLocal<T>`. Sessions flow through `await` and `Task.Run`.
+Code that suppresses execution context flow needs extra setup.
+For `TestServer`, use `TrackQueries` or follow the
+[manual setup](../troubleshooting/README.md#4-testserver-is-not-flowing-executioncontext).
 
-The limitation is the same mechanism: work that suppresses context flow is not captured. In practice the
-one place this bites is `TestServer`, which does not flow context into requests unless asked. See
-[troubleshooting](../troubleshooting/README.md#4-testserver-is-not-flowing-executioncontext).
-
-The interceptor **observes**. It never modifies the generated SQL, suppresses a command, changes a result,
-or replaces an exception. See [ADR-0002](../decisions/0002-session-propagation.md) and
-[ADR-0006](../decisions/0006-aspnet-observe-only.md).
+See [session design](../decisions/0002-session-propagation.md).
 
 ## 3. A fingerprint decides what "the same query" means
 
-To say "this query ran 51 times", QueryGuard has to decide when two command texts are the same query.
-Raw text will not do: provider-generated parameter names differ between executions, and formatting
-differs between providers and EF versions.
+A fingerprint is a query ID such as `QG-FP-1A2B3C4D`. QueryGuard creates it by:
 
-The command text is **normalized** by collapsing whitespace, removing non-directive comments, and
-mapping every parameter syntax to one placeholder. It is then **redacted** and hashed into a short
-stable identifier like `QG-FP-1A2B3C4D`.
+1. Collapsing whitespace and removing comments except QueryGuard directives.
+2. Replacing parameter references with a common placeholder.
+3. Redacting values according to the capture settings.
+4. Hashing the normalized, redacted SQL.
 
-Normalization is deliberately conservative. It never reorders tokens, sorts clauses, canonicalizes
-aliases, or rewrites quoted identifiers, because the two failure modes are not symmetric:
+Token order, aliases, and quoted identifiers stay unchanged. SQL from different providers can
+have different IDs.
 
-- **Over-normalizing** merges genuinely different statements, so a report points at SQL your application
-  never ran. Actively misleading.
-- **Under-normalizing** splits one logical query into several groups, so a real pattern goes unreported.
-  The tool is merely quieter.
+The built-in redactor hashes the full SQL before shortening it for display.
+Two long queries can show the same shortened text but have different IDs.
+See [display limits](../configuration/README.md#sql-display-length-and-fingerprints).
 
-When in doubt, it does less. See [ADR-0005](../decisions/0005-sql-fingerprints.md).
+## 4. Redaction happens before reporting
 
-## 4. Redaction happens once, before anything can read the data
+By default, SQL string and number values are redacted, parameter values are not captured,
+and retained SQL samples are limited. Connection strings are not captured.
 
-Everything QueryGuard retains passes through one policy. Parameter values and connection strings have no
-field anywhere in the model, string and numeric literals surviving in SQL are replaced, retained samples
-are bounded, and stack traces are off unless asked for.
+Request stack traces are off by default. Test scopes capture query origins by default.
+See [capture settings](../configuration/README.md#capture-and-privacy).
 
-Centralizing this is the point: a reporter that had to *remember* to redact would eventually forget, and
-adding a reporter would be a way to introduce a leak. Because redaction happens before a result exists,
-no reporter, including one you write, can emit what was never captured.
+## 5. Analysis happens when the scope ends
 
-See [ADR-0004](../decisions/0004-parameter-privacy.md).
+QueryGuard groups recorded commands by fingerprint and checks the configured policy.
+The result contains counts, durations, SQL samples, and findings in a stable order.
 
-## 5. Analysis happens after the work, not during it
+Repeated SQL is a possible N+1 problem. A repetition warning alone does not fail a test;
+a rule with failure severity does. See [budgets](../configuration/README.md#budgets).
 
-Capture is one append per command. Grouping, budget evaluation, and finding creation happen once when
-the scope closes.
+## Next steps
 
-That split is why being installed costs about a nanosecond per command
-([benchmarks](../benchmarks.md)). It also means analysis can afford to sort and allocate, which is what
-makes deterministic ordering affordable: two runs over the same data produce byte-identical reports, so a
-snapshot test on a report is meaningful.
-
-A **finding** is evidence, not a verdict on your design. It carries the numbers that justify it:
-occurrence counts, expected against actual, timing, redacted SQL, so you can disagree with it on the
-facts. A repeated-query candidate is a *warning*, because repeated SQL is strong evidence and not proof.
-Making it a failure requires configuring a budget, deliberately.
-
-See [ADR-0003](../decisions/0003-detector-terminology.md).
-
-## Where to go next
-
-| | |
-| --- | --- |
-| Configure budgets and policies | [configuration](../configuration/README.md) |
-| A finding looks wrong | [false positives](../troubleshooting/false-positives.md) |
-| Provider support | [providers](../providers/README.md) |
-| Why any of this is the way it is | [decision records](../decisions/README.md) |
+- [Testing](../testing/README.md)
+- [Configuration](../configuration/README.md)
+- [Intentional repetition](../troubleshooting/false-positives.md)
+- [Design decisions](../decisions/README.md)

--- a/docs/configuration/README.md
+++ b/docs/configuration/README.md
@@ -1,16 +1,15 @@
 # Configuration
 
-Every budget is opt-in. A policy with nothing configured reports what it sees and fails nothing, which
-is what makes QueryGuard safe to add to an existing project: it tells you the truth before it starts
-blocking anything.
+Budgets are opt-in. Without a budget, QueryGuard reports findings but does not fail a test.
 
 ## Registration
+
+Register the services, attach the interceptor, and add middleware after routing:
 
 ```csharp
 builder.Services.AddQueryGuard(options =>
 {
     options.Enabled = builder.Environment.IsDevelopment();
-
     options.DefaultPolicy = QueryGuardPolicy.Create("default")
         .WithMaxQueries(20, QueryGuardSeverity.Warning)
         .WithRepeatedQueryThreshold(3);
@@ -23,49 +22,40 @@ builder.Services.AddDbContext<AppDbContext>((provider, db) =>
 });
 
 var app = builder.Build();
-
 app.UseRouting();
-app.UseQueryGuard();   // after UseRouting; see below
+app.UseQueryGuard();
 ```
 
-Two things people miss:
-
-- **Attaching the interceptor is a separate step.** Registering services is not enough; EF Core has to be
-  told about it. Outside a container, `options.UseQueryGuard()` does it in one call.
-- **`UseQueryGuard()` goes after `UseRouting()`.** The scope name comes from the matched route pattern, so
-  earlier means every request lands in one `(unmatched)` scope.
+Registering services alone does not attach the interceptor.
+Without a DI container, use `options.UseQueryGuard()` when configuring EF Core.
 
 ## Budgets
 
-| Method | What it limits | Default severity |
+| Method | What it checks | Default severity |
 | --- | --- | --- |
-| `WithMaxQueries(n)` | Counted commands in the whole scope | Failure |
-| `WithMaxOccurrencesPerFingerprint(n)` | Occurrences of any one query | Failure |
-| `WithMaxDuplicateGroups(n)` | How many queries reached the repetition threshold | Failure |
-| `WithMaxTotalDuration(t)` | Summed command duration | **Warning** |
-| `WithSlowQueryThreshold(t)` | Slowest single command | Warning |
-| `WithRepeatedQueryThreshold(n)` | When a repetition becomes a candidate warning | Warning (always) |
+| `WithMaxQueries(n)` | Total counted commands | Failure |
+| `WithMaxOccurrencesPerFingerprint(n)` | Count for each query ID | Failure |
+| `WithMaxDuplicateGroups(n)` | Number of groups that reach the repetition threshold | Failure |
+| `WithMaxTotalDuration(t)` | Sum of command durations | Warning |
+| `WithSlowQueryThreshold(t)` | Slowest command | Warning |
+| `WithRepeatedQueryThreshold(n)` | Repetition count that triggers a candidate warning | Warning (always) |
 
-Every budget is a **maximum**: exactly at the limit passes.
+Maximum budgets pass at the limit. The repetition threshold warns when the count reaches it.
+Timing rules default to warnings because database speed varies between runs.
 
-Severity is per rule, and the defaults differ for a reason. Counting rules default to `Failure` because
-query count is deterministic: same code, same count. Timing rules default to `Warning` because they are
-not, and a guard that fires intermittently on a shared runner teaches people to distrust every other
-finding.
-
-**Start with `WithMaxOccurrencesPerFingerprint`.** It is the rule that actually catches an N+1: a
-total-count budget can stay satisfied while one query quietly repeats.
+To limit repeated queries:
 
 ```csharp
-QueryGuardPolicy.Create("companies")
-    .WithMaxQueries(20, QueryGuardSeverity.Warning)      // a canary
-    .WithMaxOccurrencesPerFingerprint(5);                 // the actual guard
+var policy = QueryGuardPolicy.Create("companies")
+    .WithMaxQueries(20, QueryGuardSeverity.Warning)
+    .WithMaxOccurrencesPerFingerprint(5);
 ```
+
+This warns above 20 counted commands and fails if one query runs more than five times.
 
 ## Per-endpoint policies
 
-A policy is selected by route **pattern**, so `/api/companies/1` and `/api/companies/2` share the policy
-for `GET /api/companies/{id}` rather than creating one each.
+Match the route pattern, not a specific URL. Overrides inherit `DefaultPolicy`:
 
 ```csharp
 options.ForEndpoint("GET /api/reports/{id}", policy => policy
@@ -73,159 +63,130 @@ options.ForEndpoint("GET /api/reports/{id}", policy => policy
     .WithRepeatedQueryThreshold(6));
 ```
 
-An override **starts from `DefaultPolicy`**, so a capture setting or allowlist entry added to the default
-is not silently lost for every endpoint that has an override.
-
 ## What counts as a query
 
-Reader and scalar commands count; writes do not. A budget of ten reads means ten reads regardless of how
-many entities the endpoint saves.
+Reader and scalar commands count by default. Writes do not.
+To count only reader commands:
 
 ```csharp
-policy.WithCountedKinds(QueryCommandKind.Reader);   // exclude scalars too
+policy = policy.WithCountedKinds(QueryCommandKind.Reader);
 ```
 
-Note that "what a command does" is not the same as "which EF Core method executed it". On SQLite, EF Core
-runs `INSERT … RETURNING` through the reader path to read the generated key back: QueryGuard classifies
-that as a write anyway, or a budget of ten reads would mean something different on every provider.
+QueryGuard also checks SQL for writes because EF Core can execute
+`INSERT ... RETURNING` through the reader path.
 
-Only a complete write keyword at the start of a statement marks a reader command as a write.
-Strings, quoted identifiers, and comments are skipped when finding statement boundaries. For example,
-`SELECT ';DELETE'` counts as one read, while `/* tag */ INSERT ... RETURNING ...` counts as a write.
-SQL Server batches with `SET` statements before a write keep the same behavior.
+| SQL | Classification |
+| --- | --- |
+| `SELECT ';DELETE'` | Read |
+| `/* tag */ INSERT ... RETURNING ...` | Write |
+| `SET NOCOUNT ON; INSERT ...` | Write |
 
-This is a lexical check, not a full SQL parser. CTEs and stored procedure bodies are not interpreted.
-If no clear write statement is found, QueryGuard keeps the execution kind supplied by EF Core;
-failed commands with no execution kind keep the existing read fallback.
+The check skips strings, quoted identifiers, and comments when finding statement boundaries.
+It is not a full SQL parser: CTEs and stored procedure bodies are not interpreted.
+Without a clear write statement, the EF Core execution kind is kept.
+Failed commands with no execution kind use the read fallback.
 
 ## Capture and privacy
+
+Default capture options:
 
 ```csharp
 options.Capture = new QueryGuardCaptureOptions
 {
-    CaptureParameterValues = false,   // default; leave it
-    CaptureFirstStackTrace = false,   // default; see below
-    RedactStringLiterals = true,      // default
-    RedactNumericLiterals = true,     // default
+    CaptureParameterValues = false,
+    CaptureFirstStackTrace = false,
+    RedactStringLiterals = true,
+    RedactNumericLiterals = true,
     MaxSamplesPerFingerprint = 3,
     MaxNormalizedSqlLength = 4096,
 };
 ```
 
-**`CaptureParameterValues = true` puts real user data into every report QueryGuard produces**, including
-any you then attach to a CI artifact or a public issue. It exists because a query executed with 51
-*different* keys is stronger evidence than the same query 51 times, but that is a trade to make
-deliberately.
-
-**`CaptureFirstStackTrace = true` costs 20–30× the rest of the capture path**: measured, in
-[benchmarks](../benchmarks.md). Excellent while hunting a specific repeated query on a development
-machine; not something to leave on.
-
-**`RedactNumericLiterals`** has a real trade-off: it also merges queries differing only by a literal such
-as `LIMIT 10` versus `LIMIT 100`. An inlined number is more often an identifier than a page size, so the
-default treats it as data.
+- Keep parameter values disabled to avoid putting user data into reports.
+- Connection strings are not captured.
+- Number redaction groups queries such as `LIMIT 10` and `LIMIT 100` together.
+- Set `MaxSamplesPerFingerprint = 0` to keep counts and timing without samples.
+- Stack traces add capture cost. See [benchmarks](../benchmarks.md).
 
 ## Documenting intentional repetition
 
-Never reach for a global off switch: there isn't one. Record the exception with its reason, which stays
-visible in reports:
+Add a reason next to the query or on its policy:
 
 ```csharp
-// Next to the query, when it belongs to one call site.
-db.ReportSections.TagWith("QueryGuard:Ignore reason=three-sections-bounded-by-layout")
+var sections = db.ReportSections.TagWith("QueryGuard:Ignore reason=three-sections-bounded-by-layout");
 
-// Or on the policy, when it belongs to an endpoint.
-policy.AllowFingerprint("QG-FP-1A2B3C4D", reason: "Bounded provider lookup; at most three sections.");
+policy = policy.AllowFingerprint(
+    "QG-FP-1A2B3C4D",
+    reason: "Bounded provider lookup; at most three sections.");
 ```
 
-Full guidance: [false positives](../troubleshooting/false-positives.md).
+Ignored findings stay visible with their reason.
+See [when a finding is wrong](../troubleshooting/false-positives.md).
 
 ## Logging
 
 ```csharp
-options.LogSummaryWhenClean = false;   // default
+options.LogSummaryWhenClean = false; // default
 options.ExcludedRoutePrefixes.Add("/internal");
 ```
 
-A clean request logs nothing by default. QueryGuard runs on every request, and a clean summary each time
-is noise that trains people to filter it out entirely. `/health`, `/healthz`, `/metrics`, and
-`/favicon.ico` are excluded out of the box.
+Clean requests do not log by default. These paths are excluded:
+`/health`, `/healthz`, `/metrics`, and `/favicon.ico`.
 
-Event IDs are stable and documented on `QueryGuardEventIds`: they are part of the observable contract, so
-a dashboard can be built on them. `LogLevel.Error` is reserved for QueryGuard's own failures, never for an
-application exceeding a budget, so alerting on `Error` stays meaningful.
+`QueryGuardEventIds` defines stable log event IDs.
+`LogLevel.Error` is used for QueryGuard errors, not exceeded budgets.
 
 ## Where a repeated query came from
 
-A test scope records the call site of each distinct query by default, so a failure names the code rather
-than only the SQL:
+Test scopes capture one filtered stack trace per query ID by default.
+Reports can show the application method or file and line:
 
 ```text
-  [FAIL] max-occurrences-per-fingerprint: QG-FP-FDB5F469 executed 50 times; the budget is 5.
-          SQL: SELECT COUNT(*) FROM "Departments" AS "d" WHERE "d"."CompanyId" = ?
-          origin: samples/QueryGuard.SampleApi/Program.cs:line 89
+origin: samples/QueryGuard.SampleApi/Program.cs:line 89
 ```
 
-One trace per distinct query, never one per execution. Framework and generated frames are filtered out,
-so a named method is shown by name and a lambda is shown by file and line: a minimal-API endpoint
-compiles to something like `Program.<>c.<<<Main>$>b__0_3>d.MoveNext()`, which carries no information the
-location does not.
-
-Turn it off with `captureOrigin: false`, or supply your own redactor to control capture exactly:
+Disable it for a test scope:
 
 ```csharp
 await using var scope = QueryGuardScope.Start("GET /api/companies", policy, captureOrigin: false);
 ```
 
-This is on in a scope and **off** on a request path, because it costs 20–30× the rest of the capture
-path: free in a test, not free in production. See
-[ADR-0007](../decisions/0007-stack-trace-policy.md) and [benchmarks](../benchmarks.md).
+On the request middleware path, stack traces are off by default.
+Enable them with `CaptureFirstStackTrace = true`.
+The [measured scenarios](../benchmarks.md#stack-trace-capture-why-it-is-off-by-default) were
+20–30 times slower with stack traces.
 
 ## SQL string privacy
 
-String redaction covers single-quoted strings, PostgreSQL `E'...'` escape strings, and
-`$$...$$` or `$tag$...$tag$` strings. Quotes and comment markers inside these strings stay
-inside the literal during normalization, so their contents are removed before reporting.
+String redaction covers single-quoted strings, PostgreSQL `E'...'` escape strings,
+and `$$...$$` or `$tag$...$tag$` strings.
 
-An ordinary string containing a backslash before a quote is ambiguous without the database's
-SQL mode. QueryGuard hides the remainder of that command in this case. This can shorten the
-reported SQL and group more queries together. Use parameterized SQL to avoid this ambiguity.
-Setting `RedactStringLiterals = false` explicitly keeps string contents.
+A backslash before a quote in an ordinary string is ambiguous without the database SQL mode.
+QueryGuard hides the rest of that command. This can shorten the SQL and group more queries together.
+Use parameterized SQL to avoid this ambiguity.
+
+Setting `RedactStringLiterals = false` keeps string contents in reports.
 
 ## SQL display length and fingerprints
 
-With the built-in `QueryGuardRedactor`, `MaxNormalizedSqlLength` limits the SQL kept in records and
-reports. Its default is 4096 characters, followed by a truncation marker when text is shortened.
-The fingerprint ID uses the complete normalized, redacted SQL before shortening it. Two long queries
-can therefore show the same shortened SQL while having different IDs and separate query budgets.
+With the built-in `QueryGuardRedactor`, `MaxNormalizedSqlLength` limits retained SQL to
+4096 characters by default, plus a truncation marker.
 
-Changing the display limit does not change these IDs. Values are still redacted before hashing,
-so queries that differ only in redacted values continue to share a fingerprint. After upgrading,
-review allowlists and baselines for previously truncated queries because their IDs change.
+The ID uses the **complete normalized, redacted SQL** before truncation.
+Changing the display limit does not change the ID. Long queries with different endings
+keep separate IDs and budgets, even if their displayed text looks the same.
+Queries that differ only in redacted values still share an ID.
 
-Custom `IQueryGuardRedactor` implementations keep their existing contract: the text returned by
-`RedactSql` is hashed and retained. QueryGuard cannot recover a suffix a custom redactor removed;
-use a custom `IQueryFingerprintFactory` if it needs a separate full-text hashing policy.
+After upgrading from truncated hashing, review fingerprint allowlists for long queries.
+Also review baseline counts, since previously merged query groups may now be separate.
+
+Custom `IQueryGuardRedactor` implementations return the text that is both hashed and retained.
+To hash more text than a custom redactor returns, supply a custom `IQueryFingerprintFactory`.
 
 ## In tests
 
-```csharp
-// Where the context is configured.
-options.UseSqlite(connectionString).UseQueryGuard();
+Use [`TrackQueries` for HTTP tests or `QueryGuardScope` for services](../testing/README.md).
 
-// In the test.
-await using var scope = QueryGuardScope.Start(
-    "GET /api/companies",
-    QueryGuardPolicy.Create("companies").WithMaxOccurrencesPerFingerprint(1));
-
-var response = await client.GetAsync("/api/companies");
-
-QueryGuardAssert.Passes(await scope.CompleteAsync());
-```
-
-`UseQueryGuard()` and `QueryGuardScope.Start` default to the same ambient accessor, so there is nothing
-to match up and calling `UseQueryGuard()` twice is a no-op rather than a double count. Pass an accessor
-explicitly only when the interceptor came from a container.
-
-With `WebApplicationFactory`, also set `TestServerOptions.PreserveExecutionContext`: see
-[troubleshooting](../troubleshooting/README.md#4-testserver-is-not-flowing-executioncontext).
+`UseQueryGuard()` and `QueryGuardScope.Start(...)` share the default session accessor.
+Calling `UseQueryGuard()` twice does not add a second interceptor.
+If your interceptor comes from DI, pass that container's accessor to the scope.

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -1,11 +1,6 @@
 # Architecture Decision Records
 
-Every decision here was expensive to reverse once code depended on it, so it was written
-down before or alongside the implementation rather than reconstructed afterwards.
-
-Each record states the decision, what was rejected, why, what it costs, and, most
-importantly, the **trigger** that should make us revisit it. A decision without a revisit
-trigger is a belief, not an engineering choice.
+Design records explain each decision, its trade-offs, and when to review it.
 
 | ADR | Decision | Status |
 | --- | --- | --- |

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,35 +1,36 @@
 ---
-title: Catch N+1 queries before merge
-description: Counts the EF Core queries your code actually runs, groups the repeated ones, and turns that into something a test can fail on.
+title: QueryGuard.NET
+description: Count EF Core queries and catch repeated queries in tests.
 ---
 
-# Your endpoint returns 200 OK. It also ran the same query 51 times.
+# Catch repeated EF Core queries in tests
 
-A refactor keeps the response correct, keeps the status `200`, keeps every test green, and turns one
-query into fifty. Nothing about the response says so, because tests assert *what came back*, not how
-many round trips produced it.
+QueryGuard counts database queries, groups repeated SQL, and checks query limits.
+Use it to catch possible N+1 problems before merging your code.
 
-QueryGuard counts the EF Core queries your code actually runs, groups the repeated ones, and turns that
-into something a test can fail on.
-
-> [!NOTE]
-> It reports repeated-query **candidates**. Repeated SQL is strong evidence of an N+1, not proof. Some
-> repetition is correct. Every finding says so, and every intentional exception is recorded with a
-> reason instead of hidden.
+Works with EF Core 8 and 10. See [provider support](providers/README.md).
 
 ## Install
+
+For ASP.NET Core integration tests:
 
 ```bash
 dotnet add package QueryGuard.AspNetCore.Testing
 ```
 
-This package measures real `WebApplicationFactory` requests and works with any test framework.
+Available on [NuGet](https://www.nuget.org/packages/QueryGuard.AspNetCore.Testing).
+For services and background jobs, use [QueryGuard.Testing](https://www.nuget.org/packages/QueryGuard.Testing).
 
-## Measure one request
+## Check one request
 
-Open a measurement for the application's EF Core context:
+Use your application's `Program` and `AppDbContext` types:
 
 ```csharp
+using Microsoft.AspNetCore.Mvc.Testing;
+using QueryGuard;
+using QueryGuard.AspNetCore.Testing;
+using QueryGuard.Testing;
+
 using var factory = new WebApplicationFactory<Program>();
 await using var guard = factory.TrackQueries<Program, AppDbContext>(
     "GET /api/companies",
@@ -41,11 +42,9 @@ response.EnsureSuccessStatusCode();
 QueryGuardAssert.Passes(await guard.CompleteAsync());
 ```
 
-The helper attaches QueryGuard, preserves the execution context used by `TestServer`, and prevents the
-request middleware from hiding the test scope. Outside a scope nothing is captured. See the
-[testing guide](testing/README.md) for service tests, background jobs, and manual scopes.
+The test fails if the same query runs more than five times. Always send requests through `guard.Client`.
 
-## What a failure tells you
+## Read a failure
 
 ```text
 QueryGuard FAILED: GET /api/companies (policy 'companies')
@@ -56,61 +55,25 @@ QueryGuard FAILED: GET /api/companies (policy 'companies')
           origin: samples/QueryGuard.SampleApi/Program.cs:line 89
 ```
 
-The last line is the one that saves time: it points at the code that ran the query, not just the SQL.
+The report shows the repeated query, its count, your limit, and where it ran.
+Repeated SQL can be intentional. Review each finding before changing the code.
 
-## Or skip picking a number entirely
+## Next steps
 
-`WithMaxOccurrencesPerFingerprint(5)` needs someone to know that five is right. On an endpoint nobody
-has measured, nobody does. So record what it costs today and report what changed:
-
-| Scope | Before | Now | Change |
-| --- | --: | --: | --- |
-| `GET /api/companies` | 3 | 51 | +48, most-repeated query +48 |
-| `GET /api/orders` | 8 | 8 | most-repeated query +7 |
-| `GET /api/users` | 4 | 4 | unchanged |
-| `GET /api/reports` | 12 | 3 | -9 (improved) |
-
-The `orders` row is the one worth a second look: the read count did not move, but one query is now
-running seven more of them, which a total-count budget cannot see.
-
-In CI, without writing plumbing:
-
-```bash
-dotnet tool install -g QueryGuard.Cli
-
-queryguard baseline record          # once, then commit the file
-queryguard verify --summary artifacts/queryguard/summary.md
-```
-
-```yaml
-- uses: Benziza/queryguard-dotnet@v0.1.0
-```
-
-The action posts that table as a sticky pull request comment. See [baselines](baselines/README.md).
-
-## Where to go next
-
-| | |
+| Task | Guide |
 | --- | --- |
-| [How it works](concepts/README.md) | Sessions, fingerprints, redaction, analysis |
-| [Testing](testing/README.md) | WebApplicationFactory requests and explicit scopes |
-| [Configuration](configuration/README.md) | Every budget and option, and why each default is what it is |
-| [Baselines](baselines/README.md) | Recording what a scope costs and reporting what changed |
-| [Provider support](providers/README.md) | What is integration-tested and what is merely captured |
-| [Troubleshooting](troubleshooting/README.md) | Nothing recorded, fingerprints not grouping, middleware ordering |
-| [When a finding is wrong](troubleshooting/false-positives.md) | The allowlist workflow, end to end |
-| [Decision records](decisions/README.md) | Why it behaves the way it does |
-| [API reference](api/index.md) | Generated from the source |
+| Measure requests, services, or jobs | [Testing](testing/README.md) |
+| Set query limits and capture options | [Configuration](configuration/README.md) |
+| Compare query counts with a saved result | [Baselines](baselines/README.md) |
+| Fix setup problems | [Troubleshooting](troubleshooting/README.md) |
+| Allow intentional repetition | [When a finding is wrong](troubleshooting/false-positives.md) |
+| Understand sessions and query IDs | [How it works](concepts/README.md) |
+| Browse types and methods | [API reference](api/index.md) |
 
-## Scope
+## Limits and privacy
 
-**Tested against real SQL Server, PostgreSQL, MySQL, and SQLite** in CI, on EF Core 8 and 10. Any
-relational EF Core provider is captured through the same official interception contract.
+QueryGuard captures relational EF Core commands. It does not capture Dapper or raw ADO.NET calls,
+prove an N+1 defect, or fix queries for you.
 
-It does not prove an N+1, does not see Dapper or raw ADO.NET, produces no execution plans or profiler
-UI, and will not fix your code. Profilers and APM answer *what is slow in production?* QueryGuard
-answers *did this change alter how many queries we run?* before merge, as a build failure.
-
-It reads SQL, so the defaults are the contract: no parameter values, no connection strings, nothing
-written into HTTP responses. Redaction runs centrally before any reporter sees a string, so no
-reporter, including one you write, can leak what was never captured.
+By default, reports exclude parameter values and redact SQL string and number values.
+Connection strings are not captured. See [privacy settings](configuration/README.md#capture-and-privacy).

--- a/docs/providers/README.md
+++ b/docs/providers/README.md
@@ -1,191 +1,98 @@
 # Provider support
 
-QueryGuard captures commands through EF Core's relational interception contract, which every relational
-provider implements. So in one sense every relational provider works.
-
-But the feature you care about, grouping repeated queries, depends on the *shape of the SQL the provider
-generates*. Parameter naming, quoting, and formatting all differ, and the fingerprint normalizer is
-deliberately conservative. **Capture and fingerprint quality are two different claims**, and blurring them
-is how a support matrix becomes a lie.
+QueryGuard captures commands through EF Core's relational interceptor API.
+SQL grouping depends on the provider's SQL format, so test coverage varies.
 
 ## The matrix
 
-| Provider | Tier | What that means |
-| --- | --- | --- |
-| SQLite | **Integration-tested** | Real commands run in CI, on Ubuntu and Windows, on `net8.0` and `net10.0` |
-| PostgreSQL (Npgsql) | **Integration-tested** | Focused Testcontainers suite in CI |
-| SQL Server | **Integration-tested** | Real commands run in CI through Testcontainers |
-| MySQL | **Integration-tested** | Real commands run in CI through Testcontainers, via Oracle's provider: [see the caveat](#the-mysql-provider-caveat) |
-| MariaDB | Community | No tests, no promises. Wire-compatible with MySQL, which is evidence and not verification |
-| Other relational providers | Best effort | Works through the official interception contract |
-| Non-relational EF providers | **Unsupported** | `DbCommand` interception is relational only |
+| Provider | Coverage |
+| --- | --- |
+| SQLite | Live CI tests on Ubuntu and Windows, on .NET 8 and 10 |
+| PostgreSQL (Npgsql) | Live CI tests with Testcontainers |
+| SQL Server | Live CI tests with Testcontainers |
+| MySQL | Live CI tests with Oracle's provider; [see below](#the-mysql-provider-caveat) |
+| MariaDB | Community use; no live test suite |
+| Other relational providers | Best effort; SQL grouping may need more tests |
+| Non-relational EF providers | Unsupported |
 
-"Integration-tested" means real database commands run in CI. "Fixture-verified" means the normalizer is
-checked against captured SQL from that provider, but nothing live runs. See
-[ADR-0009](../decisions/0009-provider-matrix.md).
+**Integration-tested** means real database commands run in CI.
+**Fixture-verified** means saved SQL is tested without a live database.
+See [support policy](../decisions/0009-provider-matrix.md).
 
-Every one of those live suites has found something. SQL Server was fixture-verified until a live suite
-was added, and the first run found [a shipped bug](#what-the-live-sql-server-suite-found). MySQL found
-[a reporting bug affecting every provider](#what-the-live-mysql-suite-found). That is the argument for
-the tier distinction, restated twice.
+## The MySQL provider caveat
 
-## Why these four, specifically
+The suite uses `MySql.EntityFrameworkCore` from Oracle.
+Pomelo SQL is not covered by this suite. Test your application's queries if you use Pomelo.
 
-**SQLite is the workhorse.** Real relational execution, no container, fast enough to run the whole
-surface: interception, fingerprinting, budgets, middleware, and failure paths on every pull request.
+## Parameter syntaxes the normalizer handles
 
-**PostgreSQL exists to prove the design is not accidentally SQLite-shaped.** Npgsql generates positional
-`$1` parameters and quotes differently. With one provider, a dialect assumption could hide in the
-normalizer indefinitely; the second data point is what makes the generic approach credible. It also
-caught the case that had to be handled explicitly: PostgreSQL's `::` cast operator looks like the start of
-a named parameter, and treating it as one silently merged queries that differ by type.
+These parameter references become one common placeholder:
 
-**SQL Server is the provider most .NET developers check first**, so "probably works" was not a good
-enough answer for it. It also has the most distinctive generated SQL of the four: a parameter
-declaration prologue in front of the actual statement, which turned out to matter more than expected.
+| Syntax | Common use |
+| --- | --- |
+| `@p0`, `@__city_0` | SQL Server, SQLite, MySQL |
+| `$1`, `$2` | PostgreSQL positional parameters |
+| `:name` | Named parameters |
+| `?` | Positional parameters |
 
-**MySQL brings the third quoting style and the inlining case.** Backticks are a distinct third form
-after `"` and `[]`, and MySQL inlines some constants the other providers parameterize, so where the
-SQL Server suite exercises the parameter path, MySQL exercises literal redaction. Both have to end up
-hiding the value, and only running both shows that they do.
+PostgreSQL `::` casts are preserved.
+
+## What is not normalized
+
+Identifier quoting stays unchanged. `"Departments"`, `[Departments]`, and
+`` `Departments` `` can produce different fingerprints.
+
+Fingerprint allowlists can therefore differ between providers.
+Use a [query tag](../troubleshooting/false-positives.md#3-allowlist-by-tag) for an exception
+that should apply across providers.
+
+## Running the provider suite
+
+```bash
+dotnet test tests/QueryGuard.ProviderTests
+```
+
+SQLite runs without Docker. With Docker running, the PostgreSQL, SQL Server, and MySQL
+tests run too. Container tests skip when Docker is unavailable locally; CI runs them.
+
+## Using an untested provider
+
+Check the SQL shown in reports:
+
+| What you see | Possible cause |
+| --- | --- |
+| One logical query has several IDs | SQL differences are not normalized |
+| Different queries share one ID | Normalization or redaction removed a meaningful difference |
+
+Open a [provider report](https://github.com/Benziza/queryguard-dotnet/issues/new?template=provider_report.yml)
+with synthetic or fully redacted SQL.
 
 ## What the live SQL Server suite found
 
-A bug that had shipped, and that fixtures could not have caught.
+SQL Server can put `SET` statements before an insert:
 
-EF Core's insert batch on SQL Server does not begin with the interesting statement:
-
-```text
+```sql
 SET IMPLICIT_TRANSACTIONS OFF;
 SET NOCOUNT ON;
 INSERT INTO [Departments] ([Id], [CompanyId], [Name]) VALUES (@p0, @p1, @p2);
 ```
 
-QueryGuard decides whether a command is a read or a write from its leading keyword, because the
-execution method alone is provider-dependent: on SQLite an `INSERT … RETURNING` runs through the
-reader path. It saw `SET`, concluded "not a modification", and left the command classified as a read.
-So **every `SaveChanges` on SQL Server consumed a read budget**, and a budget of ten reads meant
-something different there than on SQLite, quietly.
-
-Classification now walks every statement in the batch rather than only the first. The shapes are pinned
-by unit tests that run without Docker, so the regression is caught on every pull request; the live suite
-is what noticed it existed.
-
-The general lesson, which is why the tier distinction is kept: a fixture proves the normalizer still
-does what it did when the fixture was written. It cannot notice SQL the fixture never contained.
-
-## The MySQL provider caveat
-
-The suite runs against **`MySql.EntityFrameworkCore`**, Oracle's provider, not Pomelo.
-
-Pomelo is the more widely used of the two by a wide margin, so this is worth stating plainly rather
-than leaving in a package file: its latest release is `9.0.0` and there is no EF Core 10 line, while
-this project targets EF Core 8 and 10. There was no version of Pomelo the suite could have used.
-
-What is verified, precisely: QueryGuard captures and groups MySQL SQL **as Oracle's provider generates
-it**. Since a fingerprint is derived from the SQL text, a Pomelo user's SQL may differ in ways this
-suite cannot see. Capture is unaffected: that goes through EF Core's interception contract, which both
-providers implement identically.
-
-If you run Pomelo and see either failure mode from [the table below](#using-an-untested-provider), it is
-worth reporting even though MySQL reads as integration-tested. When Pomelo ships an EF Core 10 line,
-running the same suite against it is a small change.
+Earlier classification counted this as a read. QueryGuard now checks statement boundaries
+throughout the batch. See [query classification](../configuration/README.md#what-counts-as-a-query).
 
 ## What the live MySQL suite found
 
-Not a MySQL bug. A bug in what **every** provider reported.
+A QueryGuard directive in a line comment could make the reported SQL look commented out
+after whitespace normalization. Directives now use block comments:
 
-`TagWith` emits the tag as a line comment, and normalization collapses runs of whitespace, including
-the line break that terminated the comment. A recognized `QueryGuard:` directive has to survive that
-pass, because it changes behaviour, and it was being kept in the form it arrived in:
-
-```text
---QueryGuard:Ignore reason=bounded-reference-lookup SELECT `c`.`Id`, `c`.`City` FROM `Companies` AS `c`
+```sql
+/*QueryGuard:Ignore reason=bounded-reference-lookup*/ SELECT `c`.`Id` FROM `Companies` AS `c`
 ```
 
-One line, and everything after the `--` is inside the comment. Every reporter prints that text, so the
-SQL shown for any tagged query read as entirely commented out, and pasting it into a client ran
-nothing. An ignored finding is still reported, with its reason, so this was on a path users see.
-
-A directive is now normalized to a block comment whichever way it was written:
-
-```text
-/*QueryGuard:Ignore reason=bounded-reference-lookup*/ SELECT `c`.`Id`, `c`.`City` FROM `Companies` AS `c`
-```
-
-The block-comment branch was already correct, and a test named for exactly this concern already covered
-it. The line-comment branch had the same intent and the opposite outcome, and the assertions on it
-checked that `QueryGuard:Ignore` appeared somewhere in the string, which stayed true throughout. A
-substring assertion cannot see a delimiter bug.
-
-Two smaller consequences, both improvements: the same directive written `--` or `/* */` now produces one
-fingerprint instead of two, which is right because the delimiter is not part of what the query does; and
-the fingerprint id of a tagged query changed, so an allowlist entry keyed on one needs the new value.
-Baselines are unaffected: they store counts, not fingerprint ids.
-
-## Parameter syntaxes the normalizer handles
-
-All of these become a single placeholder, which is what lets a per-parent query in a loop group into one
-fingerprint instead of N:
-
-| Syntax | Where it comes from |
-| --- | --- |
-| `@p0`, `@__city_0` | SQL Server, SQLite, MySQL |
-| `$1`, `$2` | PostgreSQL positional |
-| `:name` | Oracle, some Npgsql configurations |
-| `?` | Positional placeholders |
-
-Without this, provider-generated identifiers alone would split one logical query into N groups: precisely
-the case QueryGuard exists to find.
-
-## What is *not* normalized
-
-Identifier quoting is left exactly as written: `"Departments"`, `[Departments]`, and `` `Departments` ``
-are three different fingerprints. That is deliberate. A table name is structure rather than data, and
-rewriting it would mean the report shows SQL your application never ran.
-
-The practical consequence: **a fingerprint is provider-specific.** An allowlist entry recorded against
-SQLite will not match the same logical query on PostgreSQL. Allowlist by *tag* when a project runs more
-than one provider.
-
-## Running the provider suite
-
-```bash
-# SQLite only: no Docker needed
-dotnet test tests/QueryGuard.ProviderTests
-
-# With Docker running, the PostgreSQL, SQL Server, and MySQL tests execute too (a few minutes)
-docker info && dotnet test tests/QueryGuard.ProviderTests
-```
-
-The container-backed tests skip themselves when no Docker daemon is reachable, with a skip reason that
-says so. A contributor without Docker gets a green run; CI runs them for real.
-
-That skip is for an unavailable environment, not for a flaky test. A container that starts and then
-produces inconsistent results is a bug to diagnose, not to retry away.
-
-## Using an untested provider
-
-It will probably work. Capture uses the official contract, so commands will be recorded and grouped. What
-is unverified is whether *your* provider's SQL formatting produces equally good fingerprint grouping.
-
-Two failure modes to watch for, and what each means:
-
-| What you see | What it means |
-| --- | --- |
-| One logical query appears as several fingerprints | Under-normalization. Real patterns go unreported: the tool is quiet, not wrong |
-| Two different queries share a fingerprint | Over-normalization. **Report this.** A report pointing at the wrong SQL is worse than no report |
-
-Either is worth a
-[provider report](https://github.com/Benziza/queryguard-dotnet/issues/new?template=provider_report.yml).
-A synthetic SQL sample becomes a fixture, which is the cheapest way to widen coverage, and the fastest
-route from "best effort" to "fixture-verified" for a provider you depend on.
-
-Use synthetic or fully redacted SQL. Do not paste production schema names into a public issue.
+Line and block forms of the same directive now share an ID.
+Review fingerprint allowlists when upgrading from the old behavior.
 
 ## Widening the matrix
 
-A provider moves to "integration-tested" when there is both a suite and someone willing to maintain it.
-Adding providers is the easiest way to feel productive and the fastest way to lose a release: each one is
-a container in CI, a set of fixtures, and a source of flakiness, so the bar is a contribution that comes
-with its own upkeep, not a request.
+A new integration-tested provider needs a live test suite and someone to maintain it.
+SQL fixtures are also welcome.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,88 +1,48 @@
 # Roadmap
 
-This roadmap describes direction, not a schedule. Real usage and false-positive reports decide what
-moves next. Open an [issue or discussion](https://github.com/Benziza/queryguard-dotnet/issues/new/choose)
-to add evidence.
+This is a direction, not a release schedule.
+Share use cases through [issues or discussions](https://github.com/Benziza/queryguard-dotnet/issues/new/choose).
 
 ## v0.1
 
-The goal is simple: install QueryGuard, run the sample, and get one actionable repeated-query finding
-in under three minutes.
-
-| Area | Shipped scope |
+| Area | Included |
 | --- | --- |
-| Core | Sessions, immutable records, findings, budgets, allowlists |
-| Isolation | `AsyncLocal` scopes, nesting, parallel stress tests |
-| Privacy | Central redaction, no parameter values or connection strings |
-| EF Core | Sync and async relational command capture on EF Core 8 and 10 |
-| Detection | Fingerprint grouping and repeated-query candidate findings |
-| ASP.NET Core | DI registration, request middleware, route policies, structured logs |
-| Testing | Explicit scopes and assertions with no test framework dependency |
-| Reporting | Console, logger, JSON, JUnit, Markdown, SARIF |
-| Baselines | Committed JSON baselines, comparison, CLI verification, CI summary action |
-| Providers | Live SQLite, PostgreSQL, SQL Server, and MySQL integration suites |
-| Packaging | NuGet packages, SourceLink, symbols, package smoke tests, trusted publishing |
+| Core | Sessions, query limits, findings, and allowlists |
+| EF Core | Sync and async relational capture on EF Core 8 and 10 |
+| Privacy | SQL redaction; parameter values disabled by default |
+| ASP.NET Core | Request middleware, route policies, and logs |
+| Testing | Request measurements, explicit scopes, and assertions |
+| Reporting | Console, logs, JSON, JUnit, Markdown, and SARIF |
+| Baselines | Saved counts, CLI comparison, and a GitHub Action |
+| Providers | Live SQLite, PostgreSQL, SQL Server, and MySQL tests |
+| Packages | NuGet packages, symbols, SourceLink, and consumer tests |
 
 ## Not planned for v0.1
 
-| Not doing | Why |
-| --- | --- |
-| Dapper and raw ADO.NET | The first release is limited to one verified capture surface |
-| Perfect semantic N+1 proof | SQL repetition is evidence, not enough information for proof |
-| Execution plan analysis | It is a different and provider-specific problem |
-| Dashboard or hosted UI | QueryGuard is a guard, not a profiler |
-| Test framework adapters | The current assertions already work with common frameworks |
-| Every EF Core provider | Fingerprint quality must be verified provider by provider |
-| Automatic query fixes | QueryGuard reports evidence and does not rewrite application code |
+- Dapper or raw ADO.NET capture.
+- Semantic proof of an N+1 defect.
+- Execution plans, a hosted dashboard, or automatic query fixes.
+- Separate test framework adapters.
+- Verified support for every EF Core provider.
 
 ## Candidates after v0.1
 
-These are ordered by current evidence. They are not commitments.
+| Idea | Next step |
+| --- | --- |
+| Count distinct parameter sets without retaining values | Review privacy design: [#114](https://github.com/Benziza/queryguard-dotnet/issues/114) |
+| Provider-specific normalization | Add it when real SQL examples show a need |
+| Policies in endpoint metadata | Define precedence: [#102](https://github.com/Benziza/queryguard-dotnet/issues/102) |
+| OpenTelemetry export | Assess demand from users |
 
-### Better evidence
-
-Classify repeated queries by parameter-set cardinality without retaining values. This could separate
-many identical lookups from many different keys, but the privacy design must be approved before code
-is written. Track it in [issue #114](https://github.com/Benziza/queryguard-dotnet/issues/114).
-
-Provider-specific normalizers remain possible when a real provider report shows that the general
-normalizer is not enough.
-
-### Easier policy placement
-
-Allow endpoint metadata to define a policy next to the endpoint it protects. The design needs clear
-precedence between metadata, route configuration, and defaults. Track it in
-[issue #102](https://github.com/Benziza/queryguard-dotnet/issues/102).
-
-### More reporting destinations
-
-SARIF, baselines, the CLI, and the pull request report action are shipped. OpenTelemetry export is the
-next plausible integration because it sends results to tools teams already use.
-
-### Adoption evidence
-
-The stable API was checked in three public projects. That work found and fixed one package dependency
-problem. The [validation notes](./case-studies/public-project-validation.md) record the results and
-limits, and [issue #117](https://github.com/Benziza/queryguard-dotnet/issues/117) is complete.
+The API was checked in three public projects. See the
+[validation results](./case-studies/public-project-validation.md).
 
 ## How priority is decided
 
-1. Correctness: isolation, capture accuracy, and no application behavior changes.
-2. Trust: privacy, false positives, and honest support claims.
-3. Activation: anything blocking a first useful result.
-4. Retention: anything that makes QueryGuard worth keeping.
-5. Reach: new providers and integrations.
+1. Correct capture and session isolation.
+2. Privacy and useful findings.
+3. Easy setup.
+4. Improvements for existing users.
+5. New providers and integrations.
 
-A reach feature waits while a correctness or trust issue is open. The issue should say why instead of
-going quiet.
-
-## Adoption checkpoint
-
-The project should keep expanding when real use produces strong signals such as:
-
-- successful compatibility checks in public projects
-- repeat users across releases
-- false-positive or provider feedback from real applications
-
-If people show interest but do not reach a first result, improve the setup and message before adding
-detectors. If direct onboarding still produces no useful adoption, stop expanding the surface.
+Usage and bug reports guide further work. If setup blocks users, improve it before adding features.

--- a/docs/testing/README.md
+++ b/docs/testing/README.md
@@ -1,20 +1,21 @@
 # Testing with QueryGuard
 
-QueryGuard can measure a real ASP.NET Core request or a smaller block of application code. Both paths
-produce the same `QueryGuardResult` and use the same assertions.
+Measure an HTTP request, a service method, or a background job. Each returns a
+`QueryGuardResult` that you can check with the same assertions.
 
 ## ASP.NET Core integration tests
 
-Install the helper package:
+Install:
 
 ```bash
 dotnet add package QueryGuard.AspNetCore.Testing
 ```
 
-Measure a request made through `WebApplicationFactory`:
+Use your application's `Program` and `AppDbContext` types:
 
 ```csharp
 using Microsoft.AspNetCore.Mvc.Testing;
+using QueryGuard;
 using QueryGuard.AspNetCore.Testing;
 using QueryGuard.Testing;
 
@@ -31,37 +32,36 @@ var result = await guard.CompleteAsync();
 QueryGuardAssert.Passes(result);
 ```
 
-`TrackQueries` handles the setup that is easy to miss in an integration test:
+The test fails if a query runs more than five times.
 
-- it attaches QueryGuard to the selected `DbContext`
-- it sets `TestServerOptions.PreserveExecutionContext`
-- it uses the session accessor from the hosted application
-- it disables QueryGuard request middleware for the measurement, so there is only one active scope
-- it avoids adding the interceptor twice when the application already uses QueryGuard
+`TrackQueries` attaches the interceptor and sets up the test host. It also disables request
+middleware during the measurement to avoid overlapping scopes.
 
-Use the client exposed by `guard`. A client created directly from the original factory does not use the
-configured test host.
-
-If the application uses more than one context, choose the context whose commands the test should
-measure. Open separate measurements when a test needs separate budgets for separate contexts.
+Use **`guard.Client`** to send requests. Choose the `DbContext` you want to measure.
+Use separate measurements for contexts that need separate budgets.
 
 ## Services and background jobs
 
-Install the general testing package:
+Install:
 
 ```bash
 dotnet add package QueryGuard.Testing
 ```
 
-Attach QueryGuard when the context is configured:
+Attach QueryGuard where you configure the context:
 
 ```csharp
+using QueryGuard.EntityFrameworkCore;
+
 options.UseSqlite(connectionString).UseQueryGuard();
 ```
 
-Then open a scope around the code under test:
+Open a scope around the code under test:
 
 ```csharp
+using QueryGuard;
+using QueryGuard.Testing;
+
 await using var scope = QueryGuardScope.Start(
     "refresh company summary",
     QueryGuardPolicy.Create("company-summary")
@@ -74,12 +74,12 @@ var result = await scope.CompleteAsync();
 QueryGuardAssert.Passes(result);
 ```
 
-`QueryGuard.Testing` brings the EF Core integration with it. It does not reference xUnit, NUnit,
-MSTest, or TUnit.
+This allows up to three counted commands, with no repeated query.
+`QueryGuard.Testing` includes the EF Core integration and works with any test framework.
 
 ## Start with a baseline when the budget is unknown
 
-A new test often has no agreed query budget. Record the current result first and compare later runs:
+Save the current result and compare later runs. This example uses xUnit:
 
 ```csharp
 var baseline = QueryGuardBaseline.FromJson(await File.ReadAllTextAsync("queryguard-baseline.json"));
@@ -88,15 +88,15 @@ var comparison = QueryGuardBaselineComparison.Compare(baseline, [result]);
 Assert.Empty(comparison.Regressions);
 ```
 
-See [baselines](../baselines/README.md) for recording the file and publishing the comparison in CI.
+See [baselines](../baselines/README.md) to create the file and use it in CI.
 
 ## Common failures
 
 | Symptom | Check |
 | --- | --- |
-| Zero commands from a `WebApplicationFactory` request | Use `TrackQueries` and its `Client` |
-| Twice the expected command count | Do not run request middleware inside an explicit test measurement |
+| Zero commands from a request | Use `TrackQueries` and its `Client` |
+| Unexpected command counts | Check for duplicate interceptors or overlapping scopes |
 | Commands appear in the wrong scope | Complete one measurement before opening the next one |
-| The test passes but the report is missing in CI | Write reports to a path anchored at the repository root |
+| Report missing in CI | Use a report path based on the repository root |
 
-See [troubleshooting](../troubleshooting/README.md) for manual session wiring and lower-level details.
+See [troubleshooting](../troubleshooting/README.md) for manual setup.

--- a/docs/toc.yml
+++ b/docs/toc.yml
@@ -2,12 +2,8 @@
   href: index.md
 - name: Guide
   items:
-    - name: How it works
-      href: concepts/README.md
     - name: Testing
       href: testing/README.md
-    - name: Public validation
-      href: case-studies/public-project-validation.md
     - name: Configuration
       href: configuration/README.md
     - name: Baselines
@@ -18,8 +14,12 @@
       href: troubleshooting/README.md
     - name: When a finding is wrong
       href: troubleshooting/false-positives.md
+    - name: How it works
+      href: concepts/README.md
     - name: Benchmarks
       href: benchmarks.md
+    - name: Public project validation
+      href: case-studies/public-project-validation.md
 - name: Decisions
   href: decisions/
 - name: Contributing

--- a/docs/troubleshooting/README.md
+++ b/docs/troubleshooting/README.md
@@ -1,32 +1,28 @@
 # Troubleshooting
 
-Four problems account for almost every question. They are in order of how often they come up.
-
-| Symptom | Jump to |
+| Problem | Go to |
 | --- | --- |
-| QueryGuard reports nothing at all | [No findings recorded](#no-findings-recorded) |
-| A finding looks wrong | [False positives](./false-positives.md) |
-| One logical query appears as several | [Fingerprints that do not group](#fingerprints-that-do-not-group) |
-| Every report says `(unmatched)` | [Middleware ordering](#middleware-ordering) |
+| No commands or findings | [Capture setup](#no-findings-recorded) |
+| A finding looks wrong | [Intentional repetition](./false-positives.md) |
+| One query has several IDs | [Fingerprint grouping](#fingerprints-that-do-not-group) |
+| Scope name is `(unmatched)` | [Middleware order](#middleware-ordering) |
+| Timing limits fail sometimes | [Duration budgets](#duration-budgets-firing-intermittently) |
+| Commands were dropped | [Scope completion](#the-report-says-commands-were-dropped) |
 
 ## No findings recorded
 
-The single most common report, and it is almost always one of five things.
+For `WebApplicationFactory` tests, start with
+[`TrackQueries` and `guard.Client`](../testing/README.md).
+For manual setup, check the following.
 
 ### 1. No scope was open
 
-QueryGuard captures nothing unless a session is active. That is deliberate: it stays silent rather
-than guessing which scope a command belongs to. A scope comes from either:
-
-- `app.UseQueryGuard()`, which opens one per request; or
-- `QueryGuardScope.Start(...)`, which opens one explicitly.
-
-With neither, the interceptor does one null check and returns.
+Capture needs an active session. Use `app.UseQueryGuard()` for requests or
+`QueryGuardScope.Start(...)` for an explicit scope.
 
 ### 2. The interceptor is not attached to the `DbContext`
 
-Registering QueryGuard's services is not enough. The interceptor has to be attached where EF Core will
-see it:
+Register QueryGuard services, then attach the interceptor:
 
 ```csharp
 builder.Services.AddDbContext<AppDbContext>((provider, db) =>
@@ -38,15 +34,13 @@ builder.Services.AddDbContext<AppDbContext>((provider, db) =>
 
 ### 3. The scope and the interceptor read different accessors
 
-The simplest fix is not to have two. `UseQueryGuard()` and `QueryGuardScope.Start` both default to the
-same ambient accessor, so this cannot happen unless you opt into it:
+Without DI, these APIs share the default accessor:
 
 ```csharp
 options.UseSqlite(connectionString).UseQueryGuard();
 ```
 
-It only applies when the interceptor came from a dependency injection container. Then hand the scope
-that container's accessor:
+If the interceptor comes from DI, pass the same container's accessor to the scope:
 
 ```csharp
 await using var scope = QueryGuardScope.Start(
@@ -57,11 +51,8 @@ await using var scope = QueryGuardScope.Start(
 
 ### 4. `TestServer` is not flowing `ExecutionContext`
 
-**This is the one that wastes the most time.** `TestServer` does not flow `ExecutionContext` into the
-request pipeline by default, and QueryGuard finds the active session through `AsyncLocal`. A scope
-opened in a test is therefore invisible to the interceptor running inside the request: the scope
-completes with zero commands, and an assertion about query counts fails for a reason that has nothing to
-do with query counts.
+A scope opened in a test needs its execution context to reach the request.
+`TrackQueries` handles this. For manual setup, configure it **before creating the client**:
 
 ```csharp
 protected override void ConfigureWebHost(IWebHostBuilder builder)
@@ -69,15 +60,12 @@ protected override void ConfigureWebHost(IWebHostBuilder builder)
         services.Configure<TestServerOptions>(options => options.PreserveExecutionContext = true));
 ```
 
-Setting `Server.PreserveExecutionContext` *after* `CreateClient()` does not work: the flag is captured
-when the client's handler is built, so it affects only the next client. That produces the confusing
-version of this problem, where some tests capture and some do not depending on execution order.
+Changing `Server.PreserveExecutionContext` after `CreateClient()` only affects later clients.
 
 ### 5. The middleware is shadowing your scope
 
-Both the middleware and an explicit scope open sessions, and the innermost one wins. In a test that
-opens its own scope against a host with `UseQueryGuard()` active, the middleware's per-request session
-shadows yours and your scope sees nothing. Disable it in the test host:
+Request middleware opens an inner session, which receives the commands instead of your test scope.
+Disable it in a host that uses explicit test scopes:
 
 ```csharp
 services.Configure<QueryGuardOptions>(options => options.Enabled = false);
@@ -85,62 +73,51 @@ services.Configure<QueryGuardOptions>(options => options.Enabled = false);
 
 ### Still nothing?
 
-- `QueryGuardOptions.Enabled` may be `false`: the sample gates it on `IsDevelopment()`.
-- The path may be excluded. `/health`, `/healthz`, `/metrics`, and `/favicon.ico` are ignored by default.
-- A clean request logs nothing unless `LogSummaryWhenClean` is set. That is not a bug; QueryGuard runs on
-  every request, and a clean summary each time is noise.
-- Writes are recorded but never grouped for repeated-query analysis. Fifty inserts produce no findings.
+- Request capture may be disabled through `QueryGuardOptions.Enabled`.
+- The path may be excluded: `/health`, `/healthz`, `/metrics`, and `/favicon.ico` are defaults.
+- Clean requests do not log unless `LogSummaryWhenClean` is enabled.
+- Writes are recorded but are excluded from repeated-query analysis.
 
 ## Fingerprints that do not group
 
-If one logical query appears as several fingerprints, a repeated-query pattern will not be reported:
-the tool goes quiet rather than wrong, which makes this failure mode easy to miss.
-
-Normalization is deliberately conservative: it collapses whitespace, removes non-directive comments,
-and replaces parameter references, but it never reorders tokens or rewrites identifiers. So two
-statements that differ in any other way are genuinely different fingerprints.
-
-Check the normalized SQL in the report. Common causes:
+Compare the normalized SQL in the report:
 
 | Cause | What to do |
 | --- | --- |
-| The queries really are different (different predicate, different projection) | Nothing: this is correct |
-| Different providers | Expected. Identifier quoting differs and is not rewritten |
-| Inlined literals differ and redaction is off | Leave `RedactNumericLiterals` and `RedactStringLiterals` on |
-| A `TagWith` tag differs between call sites | A tagged query is a distinct fingerprint by design |
-| Provider SQL varies in a way normalization does not cover | Open a [provider report](https://github.com/Benziza/queryguard-dotnet/issues/new?template=provider_report.yml) with the redacted SQL |
+| Different predicates or projections | Separate IDs are expected |
+| Different providers or identifier quoting | Separate IDs are expected |
+| Literal values differ and redaction is off | Check `RedactNumericLiterals` and `RedactStringLiterals` |
+| QueryGuard directives differ | Check tags and ignore reasons |
+| Provider SQL varies unexpectedly | Open a [provider report](https://github.com/Benziza/queryguard-dotnet/issues/new?template=provider_report.yml) |
 
-The last row is the useful one. A synthetic SQL sample from a provider becomes a fixture, which is the
-cheapest way to widen coverage.
+Ordinary comments are removed. QueryGuard directives are preserved.
+See [how fingerprints work](../concepts/README.md).
 
 ## Middleware ordering
 
-If every report is named `(unmatched)`, `UseQueryGuard()` is running before `UseRouting()`. The scope
-name comes from the matched endpoint's route pattern, and before routing there is no endpoint yet.
+Place QueryGuard after routing so scope names use the matched route:
 
 ```csharp
 app.UseRouting();
-app.UseQueryGuard();   // after routing
+app.UseQueryGuard();
 app.MapControllers();
 ```
 
-QueryGuard still works in the wrong order: it just loses the one label that makes a report useful.
+Running it before routing produces `(unmatched)` scope names.
 
 ## Duration budgets firing intermittently
 
-That is why they are off by default. Database timing varies with machine load, and a shared CI runner
-is the worst place to measure it. A duration budget belongs in an environment whose timing you control.
-If you need one in CI, set it generously and expect to revisit it.
+Database timing varies with load. Timing budgets are opt-in and default to warnings.
+Use a controlled environment for strict timing limits.
 
 ## The report says commands were dropped
 
-`RecordsDroppedAfterCompletion` means commands finished after the scope closed. Almost always
-fire-and-forget work started inside a request. The commands are genuinely outside the measured window,
-so they are counted and reported rather than silently added to a scope that had already been reported.
+`RecordsDroppedAfterCompletion` means commands finished after the scope closed.
+Await all measured work before completing the scope.
 
 ## Something else
 
 - Ask in [Discussions](https://github.com/Benziza/queryguard-dotnet/discussions).
-- File a [bug report](https://github.com/Benziza/queryguard-dotnet/issues/new?template=bug_report.yml)
-  with a minimal synthetic reproduction.
-- For a vulnerability, follow [SECURITY.md](https://github.com/Benziza/queryguard-dotnet/blob/main/SECURITY.md) rather than opening an issue.
+- Open a [bug report](https://github.com/Benziza/queryguard-dotnet/issues/new?template=bug_report.yml)
+  with a small, synthetic example.
+- Report vulnerabilities through [SECURITY.md](https://github.com/Benziza/queryguard-dotnet/blob/main/SECURITY.md).

--- a/docs/troubleshooting/false-positives.md
+++ b/docs/troubleshooting/false-positives.md
@@ -1,43 +1,15 @@
 # When a finding is wrong
 
-QueryGuard can prove exactly one thing: **the same normalized SQL executed N times in this scope.** It
-cannot prove the application-level defect. So some findings will be wrong, and this page is about what to
-do when one is.
+Repeated SQL is not always an N+1 defect. Bounded lookups, retries, polling, and paged jobs
+can repeat queries on purpose. QueryGuard can also miss an N+1 if each query has a different shape.
 
-If you are here because a finding looks wrong, you are using the tool correctly. Please
-[tell us about it](https://github.com/Benziza/queryguard-dotnet/issues/new?template=false_positive.yml):
-accepted reports become regression fixtures, which is how the defaults get better for everyone.
-
-## Why the wording matters
-
-Findings say *potential N+1* and *repeated-query candidate*, never "N+1 detected". That is not hedging;
-repeated SQL and an N+1 defect are genuinely different sets:
-
-**Repeated SQL that is not a defect**
-
-- A bounded lookup: three report sections, each fetching a reference row.
-- A deliberate poll on a fixed interval.
-- A retry after a transient failure.
-- Per-tenant fan-out in a job that handles several tenants on purpose.
-- A paged sweep whose page count happens to be high.
-
-**An N+1 defect that produces no repeated SQL**
-
-- Distinct parameterized shapes per iteration.
-- Provider SQL that varies enough to fingerprint differently.
-- A loop that queries different entity types.
-
-A tool that says "N+1 detected" and is wrong once teaches you to ignore every later finding. See
-[ADR-0003](../decisions/0003-detector-terminology.md).
+Review the count and SQL before changing a budget.
 
 ## Four ways to respond
 
-In order of preference. The first is best because it is the most specific and the most reviewable.
-
 ### 1. Document the exception on the query
 
-Best when the repetition is intentional *by design* and belongs to one call site. The declaration lives
-next to the code that needs it, so it moves with the query and is visible to anyone editing it.
+Use this when the exception belongs to one call site:
 
 ```csharp
 var sections = await db.ReportSections
@@ -46,13 +18,12 @@ var sections = await db.ReportSections
     .ToListAsync();
 ```
 
-The finding is still reported, marked **ignored**, with your reason attached. It stops affecting the
-outcome; it does not disappear.
+The finding stays in reports as **ignored**, with the reason attached.
 
 ### 2. Allowlist the fingerprint on the policy
 
-Best when the exception belongs to an endpoint rather than to a single LINQ expression, or when you cannot
-edit the query. Run it once, read the fingerprint out of the report, then record why:
+Use this when you cannot edit the query or the exception belongs to an endpoint.
+Copy the ID from a report:
 
 ```csharp
 options.ForEndpoint("GET /api/reports/{id}", policy => policy
@@ -61,67 +32,43 @@ options.ForEndpoint("GET /api/reports/{id}", policy => policy
         reason: "Bounded provider lookup; at most three report sections."));
 ```
 
-Matching by fingerprint is deliberately brittle: if the query changes, its fingerprint changes and the
-entry stops matching, so the exception has to be justified again. That is what stops an allowlist from
-quietly suppressing a query nobody recognizes any more.
+If the query's ID changes, the entry stops matching. Review the exception again.
 
 ### 3. Allowlist by tag
 
-Best when the same intentional pattern appears in several places. Survives a query changing, which is
-right for a pattern that is intentional by design rather than by accident.
+Use a tag for the same intentional pattern across several queries:
 
 ```csharp
-policy.AllowQueryTag("bounded-reference-lookup", reason: "Capped by layout, not by row count.");
+policy = policy.AllowQueryTag("bounded-reference-lookup", reason: "Capped by layout, not by row count.");
 ```
+
+This keeps matching the tag even when the SQL changes.
 
 ### 4. Raise the threshold
 
-Best when a whole endpoint legitimately repeats more than the default three times, and you do not want to
-enumerate individual queries.
+Use this when more repetition is expected across the whole endpoint:
 
 ```csharp
 options.ForEndpoint("GET /api/reports/{id}", policy => policy.WithRepeatedQueryThreshold(6));
 ```
 
-The trade-off: it loosens the guard for *every* query in that endpoint, not just the one you had in mind.
-Prefer the first three options when you can.
+This changes the candidate warning threshold for every query on that endpoint.
+It does not change a separate `WithMaxOccurrencesPerFingerprint` budget.
+Prefer a specific exception when only one query needs it.
 
 ## The reason is not optional
 
-Every allowlist mechanism requires reason text, and that is the whole design. "Turn this off" is not
-something a reviewer can evaluate. "Bounded provider lookup; at most three report sections" is clear,
-and it appears in a pull request diff where a reviewer can check it.
-
-A reason also reaches reports. If a report is shared, so is the reason. Write it for a reader who does
-not have your context.
-
-## What not to do
-
-**Do not look for a global off switch.** There is not one, deliberately. Suppressing everything is
-indistinguishable from uninstalling the tool, and it is a decision that gets made once in frustration and
-then never revisited.
-
-**Do not remove the interceptor to quiet a report.** You lose every other guard on the way. Allowlist the
-specific finding instead.
-
-**Do not raise a budget to make a red build green** without deciding whether the budget or the code was
-wrong. Budgets exist so the answer is a decision rather than a default.
+Every allowlist entry needs a reason. State why the repetition is expected and what bounds it.
+The reason appears in reports, so avoid sensitive details.
 
 ## Ignored findings stay visible
 
-An allowlisted finding appears in every output, including console, JSON, JUnit, and logs. It is marked
-as ignored and includes the reason. That is not an oversight. An allowlist that hides findings becomes the place real problems go to
-die: someone silences a query in March, the code changes in June, and nobody ever looks again.
-
-`IgnoredFindingCount` on the result makes it easy to notice when a scope is carrying more exceptions than
-anyone remembers granting.
+Console, JSON, JUnit, and log output show ignored findings and their reasons.
+Use `IgnoredFindingCount` to track the number of exceptions in a result.
 
 ## Reporting one
 
-Use the
-[false-positive form](https://github.com/Benziza/queryguard-dotnet/issues/new?template=false_positive.yml).
-It asks for the fingerprint, occurrence count, redacted normalized SQL, and, most importantly, *why the
-repetition is intentional*. That last part is what turns a report into a fixture.
+Use the [false-positive form](https://github.com/Benziza/queryguard-dotnet/issues/new?template=false_positive.yml).
+Include the query ID, count, redacted SQL, and why the repetition is intentional.
 
-Use synthetic or fully redacted SQL. Do not paste production schema names, parameter values, or customer
-data into a public issue.
+Use synthetic data. Do not include customer data, parameter values, or private schema names.


### PR DESCRIPTION
## What changed

Rewrite 14 documentation pages in simple English and put testing first in the guide menu. Shorten the home page, setup guides, troubleshooting, and reference summaries by about 51% (10,921 to 5,394 whitespace-separated words, including examples and tables).

Keep working examples, privacy and provider limits, full SQL fingerprint behavior, benchmark tables, and raw result links. Add direct NuGet links and retain returned policies in configuration examples.

## Why

The documentation repeats explanations and uses long introductions. Readers should find installation steps, examples, and answers quickly.

## How it was tested

- `dotnet docfx docs/docfx.json --warningsAsErrors`: passed with zero warnings and errors.
- `dotnet format QueryGuard.slnx --verify-no-changes --no-restore`: passed.
- `git diff origin/main --check`: passed.
- Checked 73 local links and anchors in the changed published pages.
- Inspected the home and configuration pages in the browser.

Three separate commits cover the quick start, main guides, and reference pages. Documentation only; no runtime behavior changes.