### PR TITLE
ci: group CodeQL updates and preserve NuGet compatibility

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -57,3 +57,8 @@ updates:
     labels:
       - "type:chore"
       - "dependencies"
+    groups:
+      # init and analyze share configuration and must use the same action version.
+      codeql:
+        patterns:
+          - "github/codeql-action/*"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -197,7 +197,7 @@ jobs:
           matrix.os == 'ubuntu-latest'
           && github.event_name == 'pull_request'
           && github.event.pull_request.head.repo.full_name == github.repository
-        uses: github/codeql-action/upload-sarif@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
+        uses: github/codeql-action/upload-sarif@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
         with:
           sarif_file: artifacts/queryguard/queryguard.sarif
           category: queryguard

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -40,7 +40,7 @@ jobs:
             10.0.x
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
+        uses: github/codeql-action/init@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
         with:
           languages: csharp
           build-mode: manual
@@ -54,6 +54,6 @@ jobs:
           dotnet build QueryGuard.slnx -c Release --no-restore
 
       - name: Perform CodeQL analysis
-        uses: github/codeql-action/analyze@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
+        uses: github/codeql-action/analyze@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
         with:
           category: "/language:csharp"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -83,6 +83,17 @@ Draft pull requests are welcome. Keep the scope focused, explain unusually large
 review conversations before merge. The repository uses squash merges, so the final pull request title
 becomes the commit message.
 
+## Dependency updates
+
+Update all `github/codeql-action/*` steps together. `init` and `analyze` must use the same version.
+Dependabot groups their version updates in one pull request.
+
+In `Directory.Packages.props`, shipping projects use low supported dependency versions while tests
+and samples use newer patches. Review the `IsPackable` conditions before accepting a NuGet update.
+A patch update for tests should not raise the minimum version required by package consumers.
+Raise that minimum only when a security fix or required API makes it necessary, and update the
+matching checks in `eng/verify-packages.sh` with the reason in the pull request.
+
 ## Documentation site
 
 Build the local site with:

--- a/eng/verify-packages.sh
+++ b/eng/verify-packages.sh
@@ -142,6 +142,13 @@ for name in "${EXPECTED_PACKAGES[@]}"; do
     fail "licence expression missing or not MIT"
   fi
 
+  if [ "$name" = "QueryGuard.Core" ]; then
+    require_dependency_version "$nuspec" "Microsoft.Extensions.Logging.Abstractions" "8.0.2" \
+      "net8.0 logging dependency starts at the supported floor"
+    require_dependency_version "$nuspec" "Microsoft.Extensions.Logging.Abstractions" "10.0.0" \
+      "net10.0 logging dependency starts at the supported floor"
+  fi
+
   if [ "$name" = "QueryGuard.EntityFrameworkCore" ]; then
     require_dependency_version "$nuspec" "Microsoft.EntityFrameworkCore.Relational" "8.0.1" \
       "net8.0 EF Core dependency starts at the supported floor"


### PR DESCRIPTION
## What changed

Update CodeQL init, analyze, and upload-sarif together to 4.37.9, pinned to the same verified commit. Group future CodeQL version updates in Dependabot.

Keep the existing NuGet dependency minimums and add package validation for Logging.Abstractions 8.0.2 / 10.0.0. Document how to review dependency minimums separately from test patch updates.

## Why

Separate init and analyze updates in #138 and #140 fail because they load configuration written by a different action version. This replaces #138, #139, and #140.

The changes in #135, #136, and #137 only raise shipping dependency minimums. Tests already use Logging.Abstractions 8.0.3 and EF Core / MVC Testing 8.0.30. Existing validation catches the EF Core and MVC Testing changes; the new check also catches the logging change. No open Dependabot alerts were reported during review.

## How it was tested

- Verified the 4.37.9 action tag resolves to the pinned commit.
- Bash syntax check and git whitespace check passed.
- Packed all seven shipping projects for .NET 8 and .NET 10.
- Full package verification passed, including the consumer and CLI smoke tests.
- Changed a copy of the packed Core nuspec to require Logging.Abstractions 8.0.3: validation rejected it with exactly the expected logging-floor failure.
- dotnet format QueryGuard.slnx --verify-no-changes --no-restore passed.
- All GitHub checks passed, including CodeQL analysis, both framework test passes, provider tests, package validation, and the docs build.

Three separate commits cover action versions, Dependabot grouping, and dependency validation.