### PR TITLE
release: prepare QueryGuard.NET 0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ record: breaking changes, privacy-relevant behavior, and report-schema compatibi
 
 ## [Unreleased]
 
+## [0.1.1] - 2026-09-05
+
+Bug fixes for SQL privacy, query counts, and long query fingerprints.
+Public APIs and report schemas are unchanged.
+
 ### Fixed
 
 - Compute built-in fingerprints from the full redacted SQL before shortening report text. Long
@@ -31,6 +36,20 @@ record: breaking changes, privacy-relevant behavior, and report-schema compatibi
   shorten SQL evidence and group more queries together. Fingerprints for affected SQL change;
   review related baselines and fingerprint allowlists after upgrading. Public APIs and report
   schemas are unchanged.
+
+### Changed
+
+- Simplify the README and documentation with shorter explanations and practical examples.
+- Update and group CodeQL actions, update Pages deployment, and check the logging dependency
+  minimum during package validation. Shipping dependency minimums stay unchanged.
+
+### Upgrading from 0.1.0
+
+- Update the QueryGuard packages you use to `0.1.1`.
+- Review fingerprint allowlists for long queries and SQL affected by the string-redaction fixes.
+  Their IDs can change. Copy new IDs only after confirming the repetition is still intentional.
+- Run measured tests again and review baseline differences before recording and committing a new
+  baseline. Corrected read counts and query grouping can change the results.
 
 ## [0.1.0] - 2026-08-21
 
@@ -342,7 +361,8 @@ release.
   `Properties/launchSettings.json`, and corrected the query and warning counts quoted in
   `samples/README.md` to what the sample actually logs.
 
-[Unreleased]: https://github.com/Benziza/queryguard-dotnet/compare/v0.1.0...main
+[Unreleased]: https://github.com/Benziza/queryguard-dotnet/compare/v0.1.1...main
+[0.1.1]: https://github.com/Benziza/queryguard-dotnet/compare/v0.1.0...v0.1.1
 [0.1.0]: https://github.com/Benziza/queryguard-dotnet/compare/v0.1.0-preview.6...v0.1.0
 [0.1.0-preview.6]: https://github.com/Benziza/queryguard-dotnet/compare/v0.1.0-preview.5...v0.1.0-preview.6
 [0.1.0-preview.5]: https://github.com/Benziza/queryguard-dotnet/releases/tag/v0.1.0-preview.5

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -42,7 +42,7 @@
 
   <!-- Shared version and identity information. -->
   <PropertyGroup>
-    <VersionPrefix>0.1.0</VersionPrefix>
+    <VersionPrefix>0.1.1</VersionPrefix>
     <Authors>Mohamed Benziza</Authors>
     <Company>Mohamed Benziza</Company>
     <Product>QueryGuard.NET</Product>

--- a/action/README.md
+++ b/action/README.md
@@ -4,7 +4,7 @@ Publishes a QueryGuard query-count report to the job summary and, on a pull requ
 comment**: one comment that gets edited rather than a new one per push.
 
 ```yaml
-- uses: Benziza/queryguard-dotnet@v0.1.0
+- uses: Benziza/queryguard-dotnet@v0.1.1
 ```
 
 That is the whole thing.
@@ -48,7 +48,7 @@ jobs:
       - run: dotnet tool install -g QueryGuard.Cli
       - run: queryguard verify --summary artifacts/queryguard/summary.md
 
-      - uses: Benziza/queryguard-dotnet@v0.1.0
+      - uses: Benziza/queryguard-dotnet@v0.1.1
         with:
           summary-path: artifacts/queryguard/summary.md
 ```


### PR DESCRIPTION
## What changed

Prepare QueryGuard.NET 0.1.1: bump the shared package version, publish the three SQL bug fixes in the changelog, and update GitHub Action examples to v0.1.1.

## Why

The fixes for SQL string privacy, read command classification, and full SQL fingerprints are on main but are not included in the published 0.1.0 packages. Upgrade notes explain which fingerprint allowlists and baselines need review. Public APIs, report schemas, and dependency minimums stay unchanged.

## How it was tested

- MSBuild resolves PackageVersion to 0.1.1.
- git diff origin/main --check passed.
- All PR checks passed, including Windows/Linux builds and tests, provider tests, package validation, CodeQL, and docs.
- Release rehearsal passed: .NET 8/10 build and tests, all seven packages, consumer and CLI smoke checks.
- Local dotnet format --verify-no-changes passed.

The release uses three commits for the version, changelog, and action examples.